### PR TITLE
Bugfix/wbec flashing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-ec-firmware (1.3.2) stable; urgency=medium
+
+  * fix EC firmware updating: add a delay after option bytes written to get MCU time to rebooting
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.ru>  Tue, 16 Jul 2024 16:35:48 +0300
+
 wb-ec-firmware (1.3.1) stable; urgency=medium
 
   * wb-ec-firmware-update: add Wiren Board 8 support

--- a/tools/wb-ec-firmware-update
+++ b/tools/wb-ec-firmware-update
@@ -163,6 +163,8 @@ stm32flash -w - -S 0x1FFF7800:4 -a$BOOTLOADER_I2C_ADDR $I2C_BUS < <(echo -n -e \
     remove_overlay_and_start_drivers
     exit -1
 }
+# Need to sleep here, because MCU is rebooted after option bytes written
+sleep 0.1
 # Update firmware
 stm32flash -w $FIRMWARE -a$BOOTLOADER_I2C_ADDR $I2C_BUS || {
     echo "Can't write firmware"


### PR DESCRIPTION
На WB8 обнаружилось, что WBEC иногда не прошивается. Поисследовали и выяснили, что wb8 слишком быстрый)
Первый вызов stm32flash записывает optyon bytes, что вызывает перезагрузку МК, а на это нужно время, т.к. как минимум на RESET висит RC-цепочка на 5 мс. А время до следующей команды на проблемном wb8 было 3.3 мс