### PR TITLE
Feature/choose correct bin rebase

### DIFF
--- a/tools/wb-ec-firmware-update
+++ b/tools/wb-ec-firmware-update
@@ -1,19 +1,16 @@
 #!/bin/bash
-. /usr/lib/wb-utils/wb_env.sh
-wb_source "of"
 
-# Check that this is WB7.4 by reading compatible property from device tree
-if of_machine_match "wirenboard,wirenboard-85x"; then
+if grep -q "wirenboard,wirenboard-85x" /proc/device-tree/compatible; then
+    WBEC_SPIDEV="spi1"
     FIRMWARE_PREFIX="WB85"
-    WBEC_SPIDEV="spi1"
-elif of_machine_match "wirenboard,wirenboard-84x"; then
-    FIRMWARE_PREFIX="WB74"
-    WBEC_SPIDEV="spi1"
-elif of_machine_match "wirenboard,wirenboard-74x"; then
-    FIRMWARE_PREFIX="WB74"
+elif grep -q "wirenboard,wirenboard-84x" /proc/device-tree/compatible; then
     WBEC_SPIDEV="spi2"
+    FIRMWARE_PREFIX="WB74"
+elif grep -q "wirenboard,wirenboard-74x" /proc/device-tree/compatible; then
+    WBEC_SPIDEV="spi2"
+    FIRMWARE_PREFIX="WB74"
 else
-    echo "This Wiren Board has no EC, exiting"
+    echo "This Wiren Board has no EC (check, DTS is a proper one), exiting"
     exit 255
 fi
 
@@ -76,8 +73,12 @@ DT_OVERLAY="
 };
 "
 
+remove_overlay() {
+    rmdir $DT_OVERLAY_DIR 2>/dev/null || true
+}
+
 remove_overlay_and_start_drivers() {
-    rmdir $DT_OVERLAY_DIR
+    remove_overlay
 
     # This script may be called from bootlet in chroot
     # where we can't manage services and kernel modules,
@@ -124,6 +125,8 @@ if ! ischroot; then
     systemctl stop watchdog
 fi
 
+trap remove_overlay_and_start_drivers EXIT
+
 # Apply overlay to disable spi and enable i2c
 rmdir $DT_OVERLAY_DIR 2> /dev/null
 mkdir $DT_OVERLAY_DIR
@@ -133,14 +136,12 @@ sleep 1.0
 # Check that overlay is applied by status property
 if ! grep -q applied $DT_OVERLAY_DIR/status; then
     echo "Can't apply overlay"
-    remove_overlay_and_start_drivers
     exit -1
 fi
 
 # Find i2c bus with name i2c_wbec
 I2C_BUS=/dev/$(i2cdetect -l | grep i2c_wbec | cut -f 1 -d$'\t') || {
     echo "I2C bus not found"
-    remove_overlay_and_start_drivers
     exit -1
 }
 echo "I2C bus: $I2C_BUS"
@@ -158,30 +159,24 @@ gpioset $GPIO_BOOT0_NUM=0
 # Check that bootloader is running
 stm32flash $I2C_BUS -a$BOOTLOADER_I2C_ADDR || {
     echo "Bootloader not found"
-    remove_overlay_and_start_drivers
     exit -1
 }
 
 # Write option bytes for stay in bootloader forever
-stm32flash -w - -S 0x1FFF7800:4 -a$BOOTLOADER_I2C_ADDR $I2C_BUS < <(echo -n -e \\xAA\\xE1\\xFF\\xDB) || {
+echo -n -e \\xAA\\xE1\\xFF\\xDB | stm32flash -w - -S 0x1FFF7800:4 -a$BOOTLOADER_I2C_ADDR $I2C_BUS || {
     echo "Can't write option bytes before firmware"
-    remove_overlay_and_start_drivers
     exit -1
 }
 # Update firmware
 stm32flash -w $FIRMWARE -a$BOOTLOADER_I2C_ADDR $I2C_BUS || {
     echo "Can't write firmware"
-    remove_overlay_and_start_drivers
     exit -1
 }
 # Restore option bytes, go to main app
-stm32flash -w - -S 0x1FFF7800:4 -a$BOOTLOADER_I2C_ADDR $I2C_BUS < <(echo -n -e \\xAA\\xE1\\xFF\\xDA) || {
+echo -n -e \\xAA\\xE1\\xFF\\xDA | stm32flash -w - -S 0x1FFF7800:4 -a$BOOTLOADER_I2C_ADDR $I2C_BUS || {
     echo "Can't write option bytes after firmware"
-    remove_overlay_and_start_drivers
     exit -1
 }
 
 # For start firmware
 sleep 1.0
-
-remove_overlay_and_start_drivers

--- a/tools/wb-ec-firmware-update
+++ b/tools/wb-ec-firmware-update
@@ -1,20 +1,15 @@
 #!/bin/bash
 
-if grep -q "wirenboard,wirenboard-85x" /proc/device-tree/compatible; then
+if grep -q "wirenboard,wirenboard-8xx" /proc/device-tree/compatible 2>/dev/null; then
     WBEC_SPIDEV="spi1"
-    FIRMWARE_PREFIX="WB85"
-elif grep -q "wirenboard,wirenboard-84x" /proc/device-tree/compatible; then
+elif grep -q "wirenboard,wirenboard-74x" /proc/device-tree/compatible 2>/dev/null; then
     WBEC_SPIDEV="spi2"
-    FIRMWARE_PREFIX="WB74"
-elif grep -q "wirenboard,wirenboard-74x" /proc/device-tree/compatible; then
-    WBEC_SPIDEV="spi2"
-    FIRMWARE_PREFIX="WB74"
 else
     echo "This Wiren Board has no EC (check, DTS is a proper one), exiting"
     exit 255
 fi
 
-DEFAULT_FIRMWARE=$(ls /usr/lib/wb-ec-firmware/"$FIRMWARE_PREFIX"__*.bin | head -1)
+DEFAULT_FIRMWARES_ORDER=$(ls /usr/lib/wb-ec-firmware/*.bin 2>/dev/null || true)
 
 if [ "$1" = "--help" ]; then
     echo "Wiren Board Embedded Controller firmware update tool"
@@ -24,16 +19,16 @@ if [ "$1" = "--help" ]; then
     echo "Update process is dangerous and can brick your device!"
     echo "Ensure that you have power backup and you know what you are doing!"
     echo
-    echo "Default firmware file to flashing:"
-    echo "$DEFAULT_FIRMWARE"
-    echo "You can pass another firmware file as argument"
+    echo "Default firmwares order to flash:"
+    echo "$DEFAULT_FIRMWARES_ORDER"
+    echo "You can pass firmware file as argument"
     echo
 
     echo "Usage: $0"
     exit 0
 fi
 
-FIRMWARE=${1:-$DEFAULT_FIRMWARE}
+FIRMWARES_ORDER=$(echo -n "$1 "; echo $DEFAULT_FIRMWARES_ORDER)
 
 GPIO_RESET="EC RESET"
 GPIO_BOOT0="EC SWCLK/BOOT0"
@@ -83,7 +78,7 @@ remove_overlay_and_start_drivers() {
     # This script may be called from bootlet in chroot
     # where we can't manage services and kernel modules,
     # so this check will suppress error messages.
-    if ! ischroot; then
+    if [[ -x "$(which ischroot)" ]] && ! ischroot; then
         modprobe pwrkey-wbec
 
         systemctl restart wb-mqtt-gpio
@@ -93,11 +88,20 @@ remove_overlay_and_start_drivers() {
     fi
 }
 
-# Check firmware file exists
-if [ ! -f "$FIRMWARE" ]; then
-    echo "Firmware file $FIRMWARE not found"
-    exit -1
-fi
+is_wbec_running() {
+    remove_overlay
+    local rc=1
+    if [[ -d /sys/bus/spi/drivers/wbec/spi0.0/ ]]; then
+        hwrev=$(cat /sys/bus/spi/drivers/wbec/spi0.0/hwrev)
+        # 4 msb: 0b1010 are set in case of incorrect firmware
+        /bin/bash -c "(( ($hwrev >> 12) == 10 ))" && rc=1 || rc=0
+    else
+        # fallback way: debugfs may be not enabled in old factory-fits
+        grep -q "0d: 3cd2" /sys/kernel/debug/regmap/spi0.0/registers 2>/dev/null
+        rc=$?
+    fi
+    [ $rc -eq "0" ] && true || false
+}
 
 # Try to find GPIO
 GPIO_RESET_NUM=$(gpiofind "$GPIO_RESET") || {
@@ -109,12 +113,10 @@ GPIO_BOOT0_NUM=$(gpiofind "$GPIO_BOOT0") || {
     exit -1
 }
 
-echo "Firmware file to flashing: $FIRMWARE"
-
 # This script may be called from bootlet in chroot
 # where we can't manage services and kernel modules,
 # so this check will suppress error messages.
-if ! ischroot; then
+if [[ -x "$(which ischroot)" ]] && ! ischroot; then
     # Remove pwrkey driver
     modprobe -r pwrkey-wbec
 
@@ -127,56 +129,75 @@ fi
 
 trap remove_overlay_and_start_drivers EXIT
 
-# Apply overlay to disable spi and enable i2c
-rmdir $DT_OVERLAY_DIR 2> /dev/null
-mkdir $DT_OVERLAY_DIR
-echo "$DT_OVERLAY" | dtc -Idts -Odtb > $DT_OVERLAY_DIR/dtbo
-sleep 1.0
+# WB-EC firmware would not start on incorrect hardware (because of fw's logic)
+# => trying to flash another one
+for FIRMWARE in $FIRMWARES_ORDER; do
+    echo "Trying fw file: $FIRMWARE"
 
-# Check that overlay is applied by status property
-if ! grep -q applied $DT_OVERLAY_DIR/status; then
-    echo "Can't apply overlay"
-    exit -1
-fi
+    # Check firmware file exists
+    if [ ! -f "$FIRMWARE" ]; then
+        echo "Firmware file $FIRMWARE not found"
+        exit -1
+    fi
 
-# Find i2c bus with name i2c_wbec
-I2C_BUS=/dev/$(i2cdetect -l | grep i2c_wbec | cut -f 1 -d$'\t') || {
-    echo "I2C bus not found"
-    exit -1
-}
-echo "I2C bus: $I2C_BUS"
+    # Apply overlay to disable spi and enable i2c
+    remove_overlay
+    mkdir $DT_OVERLAY_DIR
+    echo "$DT_OVERLAY" | dtc -Idts -Odtb > $DT_OVERLAY_DIR/dtbo
+    sleep 1.0
 
+    # Check that overlay is applied by status property
+    if ! grep -q applied $DT_OVERLAY_DIR/status; then
+        echo "Can't apply overlay"
+        exit -1
+    fi
 
-# Reset to bootloader
-gpioset $GPIO_BOOT0_NUM=1
-sleep 0.1
-gpioset $GPIO_RESET_NUM=1
-sleep 0.1
-gpioset $GPIO_RESET_NUM=0
-sleep 0.5
-gpioset $GPIO_BOOT0_NUM=0
+    # Find i2c bus with name i2c_wbec
+    I2C_BUS=/dev/$(i2cdetect -l | grep i2c_wbec | cut -f 1 -d$'\t') || {
+        echo "I2C bus not found"
+        exit -1
+    }
+    echo "I2C bus: $I2C_BUS"
 
-# Check that bootloader is running
-stm32flash $I2C_BUS -a$BOOTLOADER_I2C_ADDR || {
-    echo "Bootloader not found"
-    exit -1
-}
+    # Reset to bootloader
+    gpioset $GPIO_BOOT0_NUM=1
+    sleep 0.1
+    gpioset $GPIO_RESET_NUM=1
+    sleep 0.1
+    gpioset $GPIO_RESET_NUM=0
+    sleep 0.5
+    gpioset $GPIO_BOOT0_NUM=0
 
-# Write option bytes for stay in bootloader forever
-echo -n -e \\xAA\\xE1\\xFF\\xDB | stm32flash -w - -S 0x1FFF7800:4 -a$BOOTLOADER_I2C_ADDR $I2C_BUS || {
-    echo "Can't write option bytes before firmware"
-    exit -1
-}
-# Update firmware
-stm32flash -w $FIRMWARE -a$BOOTLOADER_I2C_ADDR $I2C_BUS || {
-    echo "Can't write firmware"
-    exit -1
-}
-# Restore option bytes, go to main app
-echo -n -e \\xAA\\xE1\\xFF\\xDA | stm32flash -w - -S 0x1FFF7800:4 -a$BOOTLOADER_I2C_ADDR $I2C_BUS || {
-    echo "Can't write option bytes after firmware"
-    exit -1
-}
+    # Check, bootloader is running
+    stm32flash $I2C_BUS -a$BOOTLOADER_I2C_ADDR || {
+        echo "Bootloader not found"
+        exit -1
+    }
 
-# For start firmware
-sleep 1.0
+    # Write option bytes for stay in bootloader forever
+    echo -n -e \\xAA\\xE1\\xFF\\xDB | stm32flash -w - -S 0x1FFF7800:4 -a$BOOTLOADER_I2C_ADDR $I2C_BUS || {
+        echo "Can't write option bytes before firmware"
+        exit -1
+    }
+    # Need to sleep here, because MCU is rebooted after option bytes written
+    sleep 0.1
+    # Update firmware
+    stm32flash -w $FIRMWARE -a$BOOTLOADER_I2C_ADDR $I2C_BUS || {
+        echo "Can't write firmware"
+        exit -1
+    }
+    # Restore option bytes, go to main app
+    echo -n -e \\xAA\\xE1\\xFF\\xDA | stm32flash -w - -S 0x1FFF7800:4 -a$BOOTLOADER_I2C_ADDR $I2C_BUS || {
+        echo "Can't write option bytes after firmware"
+        exit -1
+    }
+
+    # For start firmware
+    sleep 1.0
+
+    # Firmware is correct
+    if is_wbec_running; then
+        echo "Flashed correct fw: $FIRMWARE"
+        break
+    fi
+done


### PR DESCRIPTION
Для платок wb84x (которые платки wb7) и wb85x, бинарники прошивки wbec разные,
Мы хотим один FIT для всех wb8 => внутри него сидит общая для 8x и 85x dts => мы не можем выбирать нужный бинарник по compatible

Для этого было сделано:

1. Если прошить неверный бинарник - вбек сердито моргает светодиодом (fwrev/hwrev доступны); раньше - не давал включить wb
2. Вытащены 2 флажка "вбек прошился и работает": битиками в hwrev и числом в debugfs. В factory-fit-ах уже проданных wb8 debugfs у нас не подмонтирован => флажка два
3. У скрипта-прошиватора логика "попробовать все бинарники; на каком вбек завёлся - тот правильный"

работает в живой системе; в fit и в initram