### PR TITLE
feat: Implement LED driver for WB Embedded-controller

### DIFF
--- a/include/regmap-structs.h
+++ b/include/regmap-structs.h
@@ -90,6 +90,10 @@
         /* 0xC0 */  uint16_t wbmz_enabled : 1; \
     ) \
     /*     Addr     Name            RO/RW */ \
+    m(     0xD0,    LED_CTRL,       RW, \
+        /* 0xD0 */  uint16_t led_state : 1; \
+    ) \
+    /*     Addr     Name            RO/RW */ \
     m(     0xF0,    TEST,           RW, \
         /* 0xF0 */  uint16_t send_test_message : 1; \
         /* 0xF0 */  uint16_t enable_rtc_out : 1; \


### PR DESCRIPTION
Внесены изменения требуемые для реализации управления светодиодом подключенным физически к мк STM32 с linux системы по SPI.
- Добавлен регистр хранящий состояние LED
- Изменена логика обработки pereodic для LED

Данное изменение удаляет функционал автономного управления светодиодом со стороны мк STM32 - для того чтобы реализовать управление с двух сторон нужно согласовать интерфейс режима обработки STM32.