### PR TITLE
Allow to control EC_GPIO_LED via Linux

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-ec-firmware (1.4.0) stable; urgency=medium
+
+  * Allow to control system LED from Linux
+
+ -- Ilia Skochilov <ilia.skochilov@wirenboard.com>  Mon, 23 Sep 2024 16:35:48 +0300
+
 wb-ec-firmware (1.3.2) stable; urgency=medium
 
   * fix EC firmware updating: add a delay after option bytes written to get MCU time to rebooting

--- a/include/regmap-structs.h
+++ b/include/regmap-structs.h
@@ -16,7 +16,7 @@
                         uint16_t fwrev[4]; \
                     }; \
         /* 0x06 */  uint16_t poweron_reason; \
-        /* 0x07-0x0C */ uint16_t uid[6]; \
+         /* 0x07-0x0C */ uint16_t uid[6]; \
     ) \
     /*     Addr     Name            RO/RW */ \
     m(     0x10,    RTC_TIME,       RW, \
@@ -52,6 +52,12 @@
         /* 0x47 */  uint16_t v_a2; \
         /* 0x48 */  uint16_t v_a3; \
         /* 0x49 */  uint16_t v_a4; \
+    ) \
+    /*     Addr     Name           RO/RW */ \
+    m(     0x60,   EC_SYSTEM_LED,  RW, \
+        /* 0x60 */ uint16_t mode;      \
+        /* 0x61 */ uint16_t on_ms;     \
+        /* 0x62 */ uint16_t off_ms;    \
     ) \
     /*     Addr     Name            RO/RW */ \
     m(     0x80,    GPIO,           RW, \


### PR DESCRIPTION
К микроконтроллеру WBEC подключен отдельный зелёный светодиод. Сейчас МК управляет им самостоятельно: например, мигает при работе.
Нужно протащить в юзерспейс линукса управление этим светодиодом.