### PR TITLE
Feature/check hwrev only poweron

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,11 @@
-wb-ec-firmware (2.0.0-rc3) stable; urgency=medium
+wb-ec-firmware (2.0.0-rc4) stable; urgency=medium
 
   * Add WB8.5 target
   * wb85: buzzer support
   * regmap: fix atomic: merge is_region_changed and get_region_data functions
   * regmap: full-duplex access: read region data while writing
   * wb85: add heater support
-  * check hw revision on startup
+  * check hw revision on startup (only if poweon reason is 'power_on')
   * WBMZ6-BATTERY support
   * WBMZ6-SUPERCAP support
   * add direct control for WBMZ lines for production tests

--- a/include/hwrev.h
+++ b/include/hwrev.h
@@ -11,6 +11,6 @@ enum hwrev {
     HWREV_UNKNOWN = 0xFFFF
 };
 
-void hwrev_init(void);
+void hwrev_init_and_check(void);
 enum hwrev hwrev_get(void);
 void hwrev_put_hw_info_to_regmap(void);

--- a/include/mcu-pwr.h
+++ b/include/mcu-pwr.h
@@ -15,6 +15,7 @@ enum mcu_vcc_5v_state {
     MCU_VCC_5V_STATE_ON = 1,
 };
 
+void mcu_init_poweron_reason(void);
 enum mcu_poweron_reason mcu_get_poweron_reason(void);
 void mcu_goto_standby(uint16_t wakeup_after_s);
 enum mcu_vcc_5v_state mcu_get_vcc_5v_last_state(void);

--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,7 @@ int main(void)
     RCC->IOPENR |= RCC_IOPENR_GPIOCEN;
     RCC->IOPENR |= RCC_IOPENR_GPIODEN;
     RCC->IOPENR |= RCC_IOPENR_GPIOFEN;
+
     system_led_init();
 
     // При включении начинаем всегда с low power run
@@ -50,6 +51,8 @@ int main(void)
     // Измерение проиходит в wbec_init()
     adc_init(ADC_CLOCK_NO_DIV, ADC_VREF_INT);
     while (!adc_get_ready()) {};
+
+    mcu_init_poweron_reason();
 
     hwrev_init_and_check();
 

--- a/src/main.c
+++ b/src/main.c
@@ -51,24 +51,7 @@ int main(void)
     adc_init(ADC_CLOCK_NO_DIV, ADC_VREF_INT);
     while (!adc_get_ready()) {};
 
-    // Прежде чем инициализировать всё остальное, нужно проверить совместимость железа и прошивки
-    hwrev_init();
-    if (hwrev_get() != WBEC_HWREV) {
-        // Прошивка несовместима с железом
-        // Дальше что-то делать смысла нет, т.к. мы не знаем что за железо и какие gpio чем управляют
-        // Инициализируем только системный светодиод, spi и regmap
-        // Чтобы из линукса можно было прочитать код железа и понять какую прошивку заливать
-        rcc_set_hsi_pll_64mhz_clock();
-        systick_init();
-        spi_slave_init();
-        regmap_init();
-        hwrev_put_hw_info_to_regmap();
-        // Редко мигаем светодиодом, чтобы понять что прошивка несовместима
-        system_led_blink(25, 25);
-        while (1) {
-            system_led_do_periodic_work();
-        }
-    }
+    hwrev_init_and_check();
 
     // WBMZ нужно инициализировать до wbec_init, т.к. возможно что нужно будет включаться от WBMZ
     wbmz_init();

--- a/src/mcu-pwr.c
+++ b/src/mcu-pwr.c
@@ -24,7 +24,6 @@ void mcu_init_poweron_reason(void)
     } else {
         mcu_poweron_reason = MCU_POWERON_REASON_POWER_ON;
     }
-    mcu_poweron_reason = MCU_POWERON_REASON_UNKNOWN;
 }
 
 enum mcu_poweron_reason mcu_get_poweron_reason(void)

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -145,6 +145,8 @@ void rtc_init(void)
 {
     RCC->APBENR1 |= RCC_APBENR1_PWREN | RCC_APBENR1_RTCAPBEN;
 	PWR->CR1 |= PWR_CR1_DBP;
+    // Enable internal wakeup line (for RTC)
+    PWR->CR3 |= PWR_CR3_EIWUL;
 
     // Check LSE drive capability
     if ((RCC->BDCR & RCC_BDCR_LSEDRV_Msk) != (RTC_LSE_DRIVE_CAPABILITY << RCC_BDCR_LSEDRV_Pos)) {

--- a/src/wbec.c
+++ b/src/wbec.c
@@ -162,9 +162,6 @@ void wbec_init(void)
     // Иначе управление питанием перехватится раньше, чем нужно
     // Инициализация GPIO выполняется в WBEC_STATE_VOLTAGE_CHECK
 
-    // Enable internal wakeup line (for RTC)
-    PWR->CR3 |= PWR_CR3_EIWUL;
-
     enum mcu_poweron_reason mcu_poweron_reason = mcu_get_poweron_reason();
     wbec_ctx.poweron_reason = REASON_UNKNOWN;
 


### PR DESCRIPTION
Переделал проверку hwrev: сейчас она проверяется только при первом включении МК, при остальных причинах включения (будильник, кнопка и т.д.) проверять hwrev нет смысла, т.к. прошивка не может туда попасть без изначальной проверки hwrev