### PR TITLE
Fix RTC registers check and init

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-ec-firmware (1.3.3) stable; urgency=medium
+
+  * Fix RTC regs initialization on startup
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Thu, 10 Oct 2024 10:51:01 +0300
+
 wb-ec-firmware (1.3.2) stable; urgency=medium
 
   * fix EC firmware updating: add a delay after option bytes written to get MCU time to rebooting

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -172,10 +172,11 @@ void rtc_init(void)
     if (((RTC->CR & RTC_CR_REG_MSK) != RTC_CR_REG_VAL) ||
         ((RTC->PRER & RTC_PRER_REG_MSK) != RTC_PRER_REG_VAL))
     {
-        disable_wpr();
+        start_init_disable_wpr();
         RTC->CR = RTC_CR_REG_VAL;
+        // PRER register can be written only when INIT bit is set
         RTC->PRER = RTC_PRER_REG_VAL;
-        enable_wpr();
+        end_init_enable_wpr();
     }
 
     // Если RTC не инициализирован - нужно настроить часы на дефолтную дату


### PR DESCRIPTION
Была редкая проблема, когда после первого включения частота RTC была отличной от 1 Гц. Такие контроллеры ловились производственным тестом. Помогало передергивание батарейки.
В итоге выяснил, что кварц работал на правильной частоте, а содержимое регистра RTC->PRER было битым (в моём случае 0x007F00BE, что соответствовало частоте 1.34 Гц, частота совпадала с реальностью).
В коде была проверка значений регистров при старте, но из-за того, что не выставлялся режим INIT, регистр PRER фактически не записывался.
Откуда в нём взялось кривое значение - отдельный вопрос, понять сложно. Возможно какие-то переходные процессы при включении питания.