### PR TITLE
Fix wbec update script on wb85

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-ec-firmware (2.0.0-rc6) stable; urgency=medium
+wb-ec-firmware (2.0.0-rc7) stable; urgency=medium
 
   * Add WB8.5 target
   * wb85: buzzer support
@@ -13,8 +13,9 @@ wb-ec-firmware (2.0.0-rc6) stable; urgency=medium
   * wb85: use spi pad words between address and data
   * wb-ec-firmware-update: flash single file without checking for compatibility
   * wb85: add GPIO control for MOD1 and MOD2
+  * wb-ec-firmware-update: free /dev/ttyWBE* before flashing
 
- -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Tue, 15 Oct 2024 10:22:00 +0300
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Wed, 23 Oct 2024 10:58:46 +0300
 
 wb-ec-firmware (1.3.1) stable; urgency=medium
 

--- a/tools/wb-ec-firmware-update
+++ b/tools/wb-ec-firmware-update
@@ -47,8 +47,6 @@ DT_OVERLAY="
 /dts-v1/;
 /plugin/;
 / {
-    compatible = \"wirenboard,wirenboard-740\";
-
     fragment-wbec-disable {
         target = <&wbec>;
         __overlay__ {
@@ -85,8 +83,7 @@ remove_overlay_and_start_drivers() {
     # where we can't manage services and kernel modules,
     # so this check will suppress error messages.
     if [[ -x "$(which ischroot)" ]] && ! ischroot; then
-        modprobe pwrkey-wbec
-
+        systemctl restart wb-mqtt-serial
         systemctl restart wb-mqtt-gpio
         systemctl restart wb-mqtt-adc
         systemctl restart wb-rules
@@ -106,6 +103,15 @@ is_wbec_running() {
     [ $rc -eq "0" ] && true || false
 }
 
+ask_for_reboot() {
+    echo "Reboot is required after Embedded Controller firmware update"
+    read -p "Do you want to reboot now? [y/N] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        reboot
+    fi
+}
+
 # Try to find GPIO
 GPIO_RESET_NUM=$(gpiofind "$GPIO_RESET") || {
     echo "GPIO $GPIO_RESET not found"
@@ -120,10 +126,7 @@ GPIO_BOOT0_NUM=$(gpiofind "$GPIO_BOOT0") || {
 # where we can't manage services and kernel modules,
 # so this check will suppress error messages.
 if [[ -x "$(which ischroot)" ]] && ! ischroot; then
-    # Remove pwrkey driver
-    modprobe -r pwrkey-wbec
-
-    # Stop services
+    systemctl stop wb-mqtt-serial
     systemctl stop wb-mqtt-gpio
     systemctl stop wb-mqtt-adc
     systemctl stop wb-rules
@@ -143,6 +146,8 @@ for FIRMWARE in $FIRMWARES_ORDER; do
         exit -1
     fi
 
+    # Kill processes that use wbec-uart ports
+    fuser -k -TERM /dev/ttyWBE* || true
     # Apply overlay to disable spi and enable i2c
     remove_overlay
     mkdir $DT_OVERLAY_DIR
@@ -204,3 +209,5 @@ for FIRMWARE in $FIRMWARES_ORDER; do
         break
     fi
 done
+
+ask_for_reboot

--- a/tools/wb-ec-firmware-update
+++ b/tools/wb-ec-firmware-update
@@ -138,7 +138,9 @@ for FIRMWARE in $FIRMWARES_ORDER; do
     fi
 
     # Kill processes that use wbec-uart ports
-    fuser -k -TERM /dev/ttyWBE* || true
+    if [[ -x "$(which fuser)" ]]; then
+        fuser -k -TERM /dev/ttyWBE* || true
+    fi
     # Apply overlay to disable spi and enable i2c
     remove_overlay
     mkdir $DT_OVERLAY_DIR

--- a/tools/wb-ec-firmware-update
+++ b/tools/wb-ec-firmware-update
@@ -103,15 +103,6 @@ is_wbec_running() {
     [ $rc -eq "0" ] && true || false
 }
 
-ask_for_reboot() {
-    echo "Reboot is required after Embedded Controller firmware update"
-    read -p "Do you want to reboot now? [y/N] " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        reboot
-    fi
-}
-
 # Try to find GPIO
 GPIO_RESET_NUM=$(gpiofind "$GPIO_RESET") || {
     echo "GPIO $GPIO_RESET not found"
@@ -210,4 +201,5 @@ for FIRMWARE in $FIRMWARES_ORDER; do
     fi
 done
 
-ask_for_reboot
+echo
+echo "Reboot is required after Embedded Controller firmware update"


### PR DESCRIPTION
Потестил скрипт на wb85 с работающим опросом wbec-uart портов и обнаружил, что он не может применить оверлей в этом случае. Добавил останов wb-mqtt-serial и на всякий случай ещё fuser чтобы наверняка убить процессы. Также давно хотел добавить запрос на перезагрузку в конце. Проверил на 74, 84 и 85, работает