### PR TITLE
gpio-subsytem: Initialize gpio_dir as constant

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-ec-firmware (2.0.1) stable; urgency=medium
+
+  * Initialize gpio_dir as constant
+
+ -- Ilia Skochilov <ilia.skochilov@wirenboard.com>  Tue, 19 Nov 2024 10:02:10 +0300
+
 wb-ec-firmware (2.0.0) stable; urgency=medium
 
   * Add WB8.5 target

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-ec-firmware (2.0.1) stable; urgency=medium
 
-  * Initialize gpio_dir as constant
+  * Define INPUTS_ONLY_GPIOS and OUTPUTS_ONLY_GPIOS as macros
 
  -- Ilia Skochilov <ilia.skochilov@wirenboard.com>  Tue, 19 Nov 2024 10:02:10 +0300
 

--- a/src/gpio-subsytem.c
+++ b/src/gpio-subsytem.c
@@ -65,7 +65,7 @@ struct gpio_ctx {
 
 static struct gpio_ctx gpio_ctx = {
     .gpio_ctrl = 0,
-    .gpio_dir = outputs_only_gpios,
+    .gpio_dir = BIT(EC_EXT_GPIO_V_OUT),
 };
 
 static inline void set_v_out_state(bool state)

--- a/src/gpio-subsytem.c
+++ b/src/gpio-subsytem.c
@@ -16,8 +16,12 @@
 
 // Значения в регионе GPIO_AF (по 2 бита на пин)
 
-#define INPUTS_ONLY_GPIOS (BIT(EC_EXT_GPIO_A1) | BIT(EC_EXT_GPIO_A2) | BIT(EC_EXT_GPIO_A3) | BIT(EC_EXT_GPIO_A4))
-#define OUTPUTS_ONLY_GPIOS (BIT(EC_EXT_GPIO_V_OUT))
+#define INPUTS_ONLY_GPIOS \
+    (BIT(EC_EXT_GPIO_A1) | \
+     BIT(EC_EXT_GPIO_A2) | \
+     BIT(EC_EXT_GPIO_A3) | \
+     BIT(EC_EXT_GPIO_A4))
+#define OUTPUTS_ONLY_GPIOS              (BIT(EC_EXT_GPIO_V_OUT))
 
 enum gpio_regmap_af {
     GPIO_REGMAP_AF_GPIO = 0,


### PR DESCRIPTION
Данное изменение исправляет ошибку, которая возникала при сборке.

arm-none-eabi-gcc (GNU Tools for Arm Embedded Processors 7-2018-q2-update) 7.3.1 20180622 (release) [ARM/embedded-7-branch revision 261907]

src/gpio-subsytem.c:68:17: error: initializer element is not constant
     .gpio_dir = outputs_only_gpios,
                 ^~~~~~~~~~~~~~~~~~
src/gpio-subsytem.c:68:17: note: (near initialization for 'gpio_ctx.gpio_dir')
make[1]: *** [build/WB74/build/gpio-subsytem.o] Error 1
