### PR TITLE
Bugfix/wdt period

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-ec-firmware (2.0.1) stable; urgency=medium
+
+  * fix stm32 watchdog period: set to 10 seconds
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Fri, 22 Nov 2024 17:14:18 +0300
+
 wb-ec-firmware (2.0.0) stable; urgency=medium
 
   * Add WB8.5 target

--- a/include/wdt-stm32.h
+++ b/include/wdt-stm32.h
@@ -8,7 +8,7 @@
 
 // период в 10 секунд выбран, т.к. ЕС уходит в спячку и не может обработать watchdog
 // спит он максимум 5 секунд
-#define WDG_PERIOD_MS                       2000
+#define WDG_PERIOD_MS                       10000
 
 static inline void watchdog_init(void)
 {


### PR DESCRIPTION
Отладочная срань как-то попала в main. Там даже в комменте написано, что период вочдога должен быть 10 секунд. Как следствие, не работал нормально спящий режим, не работало выключение при вставленной батарейке, не работал будильник