### PR TITLE
Bugfix/standby mode

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-ec-firmware (2.0.2-rc1) stable; urgency=medium
+
+  * fix standby mode entering
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Wed, 27 Nov 2024 17:24:08 +0300
+
 wb-ec-firmware (2.0.1) stable; urgency=medium
 
   * fix stm32 watchdog period: set to 10 seconds

--- a/src/mcu-pwr.c
+++ b/src/mcu-pwr.c
@@ -11,14 +11,11 @@ void mcu_init_poweron_reason(void)
     if (PWR->SR1 & PWR_SR1_SBF) {
         PWR->SCR = PWR_SCR_CSBF;
         if (PWR->SR1 & (1 << (EC_GPIO_PWRKEY_WKUP_NUM - 1 + PWR_SR1_WUF1_Pos))) {
-            PWR->SCR = (1 << (EC_GPIO_PWRKEY_WKUP_NUM - 1 + PWR_SCR_CWUF1));
+            PWR->SCR = (1 << (EC_GPIO_PWRKEY_WKUP_NUM - 1 + PWR_SCR_CWUF1_Pos));
             mcu_poweron_reason = MCU_POWERON_REASON_POWER_KEY;
         } else if (PWR->SR1 & PWR_SR1_WUFI) {
-            // PWR->SCR = PWR_SCR_CWUF;
-            // странная история, порядок бит в даташите и в заголовочнике не совпадает
-            // используем даташит
-            PWR->SCR = 0x003F;
             if (RTC->SR & RTC_SR_WUTF) {
+                RTC->SCR = RTC_SCR_CWUTF;
                 mcu_poweron_reason = MCU_POWERON_REASON_RTC_PERIODIC_WAKEUP;
             } else {
                 mcu_poweron_reason = MCU_POWERON_REASON_RTC_ALARM;
@@ -42,7 +39,10 @@ void mcu_goto_standby(uint16_t wakeup_after_s)
     rtc_set_periodic_wakeup(wakeup_after_s);
 
     // Clear WKUP flags
-    PWR->SCR = PWR_SCR_CWUF;
+    // PWR->SCR = PWR_SCR_CWUF;
+    // странная история, порядок бит в даташите и в заголовочнике не совпадает
+    // используем даташит
+    PWR->SCR = 0x003F;
 
     // SLEEPDEEP
     SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;

--- a/src/mcu-pwr.c
+++ b/src/mcu-pwr.c
@@ -14,7 +14,10 @@ void mcu_init_poweron_reason(void)
             PWR->SCR = (1 << (EC_GPIO_PWRKEY_WKUP_NUM - 1 + PWR_SCR_CWUF1));
             mcu_poweron_reason = MCU_POWERON_REASON_POWER_KEY;
         } else if (PWR->SR1 & PWR_SR1_WUFI) {
-            PWR->SCR = PWR_SR1_WUFI;
+            // PWR->SCR = PWR_SCR_CWUF;
+            // странная история, порядок бит в даташите и в заголовочнике не совпадает
+            // используем даташит
+            PWR->SCR = 0x003F;
             if (RTC->SR & RTC_SR_WUTF) {
                 mcu_poweron_reason = MCU_POWERON_REASON_RTC_PERIODIC_WAKEUP;
             } else {


### PR DESCRIPTION
Проблема: при работе от WBMZ после выключения кнопкой через какое-то время (от секунд до минут) контроллер включается.

Что удалось раскопать:
1) воспроизводится очень ненадежно, не на всех контроллерах. Любое нефункциональное изменение в коде (например дерганье gpio или даже добавление nop) приводит к тому, что воспроизводиться перестает
2) оно зависает в прошивке, а не в standby, потом его ребутает вочдог
3) зависало оно в `while (1)` после WFI в функции `mcu_goto_standby`, то есть проскакивало WFI

В коде нашлось несколько проблем:
1) криво сбрасывался флаг WKUP (пробуждение по кнопке) - не влияет на текущую проблему
2) в PWR->SCR записывался бит из другого регистра (поведение не определено)
3) и причина, насколько я смог понять, заключалась в том, что флаг RTC_SR_WUTF сбрасывался непосредственно перед переходом в standby, а даташит говорит: `This flag must be cleared by software at least 1.5 RTCCLK periods before WUTF is set to 1 again`, то есть, нужно 1.5 цикла RTC чтобы его корректно сбросить и видимо оно попадало в этот промежуток. И ещё, основное влияние оказывает фаза, то есть время выполнения кода до перехода в спячку (попадает оно на нужный фронт RTC или нет) и из-за этого влияло добавление ноп-ов. Ну а раньше оно видимо работало по чистой случайности