### PR TITLE
Bugfix/outputs ctrl

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-ec-firmware (2.0.3) stable; urgency=medium
+
+  * fix MODx gpio control in case of first calling of gpioset
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Fri, 07 Feb 2025 16:38:17 +0300
+
 wb-ec-firmware (2.0.2) stable; urgency=medium
 
   * fix standby mode entering

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-ec-firmware (2.0.3) stable; urgency=medium
 
   * fix MODx gpio control in case of first calling of gpioset
+  * do not apply offset for Vin if powered from WBMZ
 
  -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Fri, 07 Feb 2025 16:38:17 +0300
 

--- a/include/adc.h
+++ b/include/adc.h
@@ -5,7 +5,7 @@
 #include "config.h"
 
 /* ADC channels names generation*/
-#define ADC_ENUM(alias, ch_num, port, pin, rc_factor, k, offset_mv)     ADC_CHANNEL_##alias,
+#define ADC_ENUM(alias, ch_num, port, pin, rc_factor, k)     ADC_CHANNEL_##alias,
 
 enum adc_channel {
     ADC_CHANNELS_DESC(ADC_ENUM)
@@ -34,6 +34,7 @@ enum adc_vref {
 
 void adc_init(enum adc_clock clock_divider, enum adc_vref vref);
 void adc_set_lowpass_rc(enum adc_channel channel, uint16_t rc_ms);
+void adc_set_offset_mv(enum adc_channel channel, int16_t offset_mv);
 fix16_t adc_get_ch_adc_raw(enum adc_channel channel);
 int32_t adc_get_ch_mv(enum adc_channel channel);
 fix16_t adc_get_ch_mv_f16(enum adc_channel channel);

--- a/include/config_wb74.h
+++ b/include/config_wb74.h
@@ -63,20 +63,22 @@
 #define NTC_RES_KOHM                            10
 #define NTC_PULLUP_RES_KOHM                     33
 
+#define ADC_V_IN_DIODE_DROP_MV                  400
+
 #define ADC_CHANNELS_DESC(macro) \
-        /*    Channel name          ADC CH  PORT    PIN     RC      K               Offset, mV  */ \
-        macro(ADC_IN1,              10,     GPIOB,  2,      50,     1,              0           ) \
-        macro(ADC_IN2,              11,     GPIOB,  10,     50,     1,              0           ) \
-        macro(ADC_IN3,              15,     GPIOB,  11,     50,     1,              0           ) \
-        macro(ADC_IN4,              16,     GPIOB,  12,     50,     1,              0           ) \
-        macro(ADC_V_IN,             9,      GPIOB,  1,      10,     212.0 / 12.0,   400         ) \
-        macro(ADC_5V,               8,      GPIOB,  0,      10,     22.0 / 10.0,    0           ) \
-        macro(ADC_3V3,              7,      GPIOA,  7,      10,     32.0 / 22.0,    0           ) \
-        macro(ADC_NTC,              6,      GPIOA,  6,      50,     1,              0           ) \
-        macro(ADC_VBUS_DEBUG,       3,      GPIOA,  3,      10,     2.2 / 1.0,      0           ) \
-        macro(ADC_VBUS_NETWORK,     5,      GPIOA,  5,      10,     2.2 / 1.0,      0           ) \
-        macro(ADC_HW_VER,           17,     GPIOA,  13,     50,     1,              0           ) \
-        macro(ADC_INT_VREF,         13,     0,      0,      50,     1,              0           ) \
+        /*    Channel name          ADC CH  PORT    PIN     RC      K              */ \
+        macro(ADC_IN1,              10,     GPIOB,  2,      50,     1               ) \
+        macro(ADC_IN2,              11,     GPIOB,  10,     50,     1               ) \
+        macro(ADC_IN3,              15,     GPIOB,  11,     50,     1               ) \
+        macro(ADC_IN4,              16,     GPIOB,  12,     50,     1               ) \
+        macro(ADC_V_IN,             9,      GPIOB,  1,      10,     212.0 / 12.0    ) \
+        macro(ADC_5V,               8,      GPIOB,  0,      10,     22.0 / 10.0     ) \
+        macro(ADC_3V3,              7,      GPIOA,  7,      10,     32.0 / 22.0     ) \
+        macro(ADC_NTC,              6,      GPIOA,  6,      50,     1               ) \
+        macro(ADC_VBUS_DEBUG,       3,      GPIOA,  3,      10,     2.2 / 1.0       ) \
+        macro(ADC_VBUS_NETWORK,     5,      GPIOA,  5,      10,     2.2 / 1.0       ) \
+        macro(ADC_HW_VER,           17,     GPIOA,  13,     50,     1               ) \
+        macro(ADC_INT_VREF,         13,     0,      0,      50,     1               ) \
 
 // macro(ADC_HW_VER,           17,      GPIOA,  13,     50,     1,              0           )
 

--- a/include/config_wb85.h
+++ b/include/config_wb85.h
@@ -114,20 +114,22 @@
 #define NTC_RES_KOHM                            10
 #define NTC_PULLUP_RES_KOHM                     33
 
+#define ADC_V_IN_DIODE_DROP_MV                  400
+
 #define ADC_CHANNELS_DESC(macro) \
-        /*    Channel name          ADC CH  PORT    PIN     RC      K               Offset, mV  */ \
-        macro(ADC_IN1,              10,     GPIOB,  2,      50,     1,              0           ) \
-        macro(ADC_IN2,              11,     GPIOB,  10,     50,     1,              0           ) \
-        macro(ADC_IN3,              15,     GPIOB,  11,     50,     1,              0           ) \
-        macro(ADC_IN4,              16,     GPIOB,  12,     50,     1,              0           ) \
-        macro(ADC_V_IN,             9,      GPIOB,  1,      10,     212.0 / 12.0,   400         ) \
-        macro(ADC_5V,               8,      GPIOB,  0,      10,     22.0 / 10.0,    0           ) \
-        macro(ADC_3V3,              6,      GPIOA,  6,      10,     32.0 / 22.0,    0           ) \
-        macro(ADC_NTC,              5,      GPIOA,  5,      50,     1,              0           ) \
-        macro(ADC_VBUS_DEBUG,       3,      GPIOA,  3,      10,     2.2 / 1.0,      0           ) \
-        macro(ADC_VBAT,             7,      GPIOA,  7,      10,     200.0 / 100.0,  0           ) \
-        macro(ADC_HW_VER,           17,     GPIOA,  13,     50,     1,              0           ) \
-        macro(ADC_INT_VREF,         13,     0,      0,      50,     1,              0           ) \
+        /*    Channel name          ADC CH  PORT    PIN     RC      K              */ \
+        macro(ADC_IN1,              10,     GPIOB,  2,      50,     1               ) \
+        macro(ADC_IN2,              11,     GPIOB,  10,     50,     1               ) \
+        macro(ADC_IN3,              15,     GPIOB,  11,     50,     1               ) \
+        macro(ADC_IN4,              16,     GPIOB,  12,     50,     1               ) \
+        macro(ADC_V_IN,             9,      GPIOB,  1,      10,     212.0 / 12.0    ) \
+        macro(ADC_5V,               8,      GPIOB,  0,      10,     22.0 / 10.0     ) \
+        macro(ADC_3V3,              6,      GPIOA,  6,      10,     32.0 / 22.0     ) \
+        macro(ADC_NTC,              5,      GPIOA,  5,      50,     1               ) \
+        macro(ADC_VBUS_DEBUG,       3,      GPIOA,  3,      10,     2.2 / 1.0       ) \
+        macro(ADC_VBAT,             7,      GPIOA,  7,      10,     200.0 / 100.0   ) \
+        macro(ADC_HW_VER,           17,     GPIOA,  13,     50,     1               ) \
+        macro(ADC_INT_VREF,         13,     0,      0,      50,     1               ) \
 
 // Ожидание после старта прошивки и перед опросом напряжений
 // Должно быть около 10RC канала ADC_5V

--- a/src/gpio-subsytem.c
+++ b/src/gpio-subsytem.c
@@ -178,7 +178,6 @@ static void set_mod_gpio_values(uint16_t new_ctrl)
             }
         }
     #endif
-
 }
 
 static void collect_gpio_states(void)
@@ -261,5 +260,6 @@ void gpio_do_periodic_work(void)
     control_v_out();
 
     collect_gpio_states();
+
     regmap_set_region_data(REGMAP_REGION_GPIO_CTRL, &gpio_ctx.gpio_ctrl, sizeof(gpio_ctx.gpio_ctrl));
 }

--- a/src/shared-gpio.c
+++ b/src/shared-gpio.c
@@ -69,6 +69,7 @@ static inline void apply_gpio_mode(enum mod mod, enum mod_gpio mod_gpio, enum mo
         break;
 
     case MOD_GPIO_MODE_AF_UART:
+    case MOD_GPIO_MODE_PA9_AF_DEBUG_UART:
         GPIO_S_SET_AF(g, GPIO_AF_UART);
         break;
     }

--- a/src/wbec.c
+++ b/src/wbec.c
@@ -116,6 +116,13 @@ static inline const char * get_poweron_reason_string(enum linux_poweron_reason r
 
 static inline void collect_adc_data(struct REGMAP_ADC_DATA * adc)
 {
+    // При питании от WBMZ не нужно учитывать падение на диоде
+    if (wbmz_is_powered_from_wbmz()) {
+        adc_set_offset_mv(ADC_CHANNEL_ADC_V_IN, 0);
+    } else {
+        adc_set_offset_mv(ADC_CHANNEL_ADC_V_IN, ADC_V_IN_DIODE_DROP_MV);
+    }
+
     // Get voltages
     adc->v_a1 = adc_get_ch_mv(ADC_CHANNEL_ADC_IN1);
     adc->v_a2 = adc_get_ch_mv(ADC_CHANNEL_ADC_IN2);


### PR DESCRIPTION
Было две проблемы:

1) не применялось первое состояние выходов, когда режим гпио менялся со входа на выход
2) при питании от WBMZ не нужно применять оффсет к Vin