### PR TITLE
Bugfix/uart data format

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-ec-firmware (2.0.4) stable; urgency=medium
+
+  * fix uart rx data format (was always with_errors)
+
+ -- Pavel Gasheev <pavel.gasheev@wirenboard.com>  Mon, 10 Mar 2025 20:46:41 +0300
+
 wb-ec-firmware (2.0.3) stable; urgency=medium
 
   * fix MODx gpio control in case of first calling of gpioset


### PR DESCRIPTION
Пока смотрел что со стопбитами происходит обнаружил ещё проблему. На работоспособность оно по сути не влияет, но шину использует неоптимально. То есть формат был всегда "с ошибками", при выборе формата не занулялись лишние биты isr