### PR TITLE
Feature/fw 812 add 7 bits word length to uart

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-ec-firmware (2.1.0-rc1) stable; urgency=medium
+
+  * add support for various uart word length (7, 8, 9 bit)
+
+ -- Egor Panchenko <egor.panchenko@wirenboard.com>  Thu, 12 Feb 2026 18:11:00 +0300
+
 wb-ec-firmware (2.0.5) stable; urgency=medium
 
   * fix reboot loop when WBMZ is discharged

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-ec-firmware (2.1.0-rc1) stable; urgency=medium
 
-  * add support for various uart word length (7, 8, 9 bit)
+  * add support for various uart word length 7 bit
 
  -- Egor Panchenko <egor.panchenko@wirenboard.com>  Thu, 12 Feb 2026 18:11:00 +0300
 

--- a/include/uart-regmap-types.h
+++ b/include/uart-regmap-types.h
@@ -3,6 +3,15 @@
 
 #define UART_REGMAP_BUFFER_SIZE             64
 
+enum uart_word_length {
+    // values according to STM32G0 reference manual
+    UART_WORD_LEN_8 = 0,
+    UART_WORD_LEN_9 = 1,
+    UART_WORD_LEN_7 = 2,
+
+    UART_WORD_LEN_MAX_VALUE = UART_WORD_LEN_7
+};
+
 enum uart_parity {
     UART_PARITY_NONE = 0,
     UART_PARITY_EVEN = 1,
@@ -61,6 +70,7 @@ struct uart_ctrl {
     /* offset 0x01 */
     uint16_t baud_x100;
     /* offset 0x02 */
+    uint16_t word_length : 2;
     uint16_t parity : 2;
     uint16_t stop_bits : 2;
     uint16_t rs485_enabled : 1;

--- a/include/uart-regmap-types.h
+++ b/include/uart-regmap-types.h
@@ -76,7 +76,7 @@ struct uart_ctrl {
     uint16_t stop_bits : 2;
     uint16_t rs485_enabled : 1;
     uint16_t rs485_rx_during_tx : 1;
-    uint16_t word_length : 2;
+    uint16_t word_length : 2; // reserve 2 bits for 0/1 value for optional adding 6-,9-data bits modes in future
 };
 
 union uart_exchange {

--- a/include/uart-regmap-types.h
+++ b/include/uart-regmap-types.h
@@ -8,9 +8,9 @@ enum uart_word_length {
     // Такая логика выбрана для обратной совместимости (ранее было всегда 8 бит), чтобы
     // при активации бита чётности не изменялась фактическая длина данных на передачу/приём,
     // а просто добавлялся бит контроля чётности.
-    UART_WORD_LEN_6 = 6,
-    UART_WORD_LEN_7 = 7,
-    UART_WORD_LEN_8 = 8,
+    UART_WORD_LEN_6 = 0,
+    UART_WORD_LEN_7 = 1,
+    UART_WORD_LEN_8 = 2,
 
     UART_WORD_LEN_MAX_VALUE = UART_WORD_LEN_8
 };

--- a/include/uart-regmap-types.h
+++ b/include/uart-regmap-types.h
@@ -8,11 +8,10 @@ enum uart_word_length {
     // Такая логика выбрана для обратной совместимости (ранее было всегда 8 бит), чтобы
     // при активации бита чётности не изменялась фактическая длина данных на передачу/приём,
     // а просто добавлялся бит контроля чётности.
-    UART_WORD_LEN_6 = 0,
+    UART_WORD_LEN_8 = 0,
     UART_WORD_LEN_7 = 1,
-    UART_WORD_LEN_8 = 2,
 
-    UART_WORD_LEN_MAX_VALUE = UART_WORD_LEN_8
+    UART_WORD_LEN_MAX_VALUE = UART_WORD_LEN_7
 };
 
 enum uart_parity {

--- a/include/uart-regmap-types.h
+++ b/include/uart-regmap-types.h
@@ -4,12 +4,15 @@
 #define UART_REGMAP_BUFFER_SIZE             64
 
 enum uart_word_length {
-    // values according to STM32G0 reference manual
-    UART_WORD_LEN_8 = 0,
-    UART_WORD_LEN_9 = 1,
-    UART_WORD_LEN_7 = 2,
+    // Имеется в виду количество бит данных без учёта бита чётности, даже если он включён.
+    // Такая логика выбрана для обратной совместимости (ранее было всегда 8 бит), чтобы
+    // при активации бита чётности не изменялась фактическая длина данных на передачу/приём,
+    // а просто добавлялся бит контроля чётности.
+    UART_WORD_LEN_6 = 6,
+    UART_WORD_LEN_7 = 7,
+    UART_WORD_LEN_8 = 8,
 
-    UART_WORD_LEN_MAX_VALUE = UART_WORD_LEN_7
+    UART_WORD_LEN_MAX_VALUE = UART_WORD_LEN_8
 };
 
 enum uart_parity {
@@ -70,11 +73,11 @@ struct uart_ctrl {
     /* offset 0x01 */
     uint16_t baud_x100;
     /* offset 0x02 */
-    uint16_t word_length : 2;
     uint16_t parity : 2;
     uint16_t stop_bits : 2;
     uint16_t rs485_enabled : 1;
     uint16_t rs485_rx_during_tx : 1;
+    uint16_t word_length : 2;
 };
 
 union uart_exchange {

--- a/src/uart-regmap-subsystem.c
+++ b/src/uart-regmap-subsystem.c
@@ -105,6 +105,7 @@ void uart_regmap_subsystem_init(void)
         uart_ctx[i].ctrl.baud_x100 = 1152;
         uart_ctx[i].ctrl.parity = UART_PARITY_NONE;
         uart_ctx[i].ctrl.stop_bits = UART_STOP_BITS_1;
+        uart_ctx[i].ctrl.word_length = UART_WORD_LEN_8;
 
         uart_ctx[i].rx_data.ready_for_tx = 1;
 

--- a/src/uart-regmap.c
+++ b/src/uart-regmap.c
@@ -140,20 +140,38 @@ void uart_apply_ctrl(const struct uart_descr *u, bool enable_req)
     u->uart->CR2 &= ~USART_CR2_STOP;
     u->uart->CR2 |= (ctrl->stop_bits << USART_CR2_STOP_Pos);
 
+    // word length:
+    switch (ctrl->word_length)
+    {
+        default:
+        case: UART_WORD_LEN_8:
+            u->uart->CR1 &= ~USART_CR1_M;
+            break;
+        case: UART_WORD_LEN_9:
+            u->uart->CR1 &= ~USART_CR1_M1;
+            u->uart->CR1 |= USART_CR1_M0;
+            break;
+        case: UART_WORD_LEN_7:
+            u->uart->CR1 &= ~USART_CR1_M0;
+            u->uart->CR1 |= USART_CR1_M1;
+            break;
+
+    }
+
     // parity
     switch (ctrl->parity) {
     default:
     case UART_PARITY_NONE:
-        u->uart->CR1 &= ~(USART_CR1_PCE | USART_CR1_PS | USART_CR1_M);
+        u->uart->CR1 &= ~(USART_CR1_PCE | USART_CR1_PS);
         break;
 
     case UART_PARITY_EVEN:
         u->uart->CR1 &= ~USART_CR1_PS;
-        u->uart->CR1 |= USART_CR1_PCE | USART_CR1_M0;
+        u->uart->CR1 |= USART_CR1_PCE;
         break;
 
     case UART_PARITY_ODD:
-        u->uart->CR1 |= USART_CR1_PCE | USART_CR1_PS | USART_CR1_M0;
+        u->uart->CR1 |= USART_CR1_PCE | USART_CR1_PS;
         break;
     }
 
@@ -243,6 +261,10 @@ void uart_regmap_process_ctrl(const struct uart_descr *u, const struct uart_ctrl
     // valid baud 1200..115200
     if ((ctrl->baud_x100 >= 12) && (ctrl->baud_x100 <= 1152)) {
         ctx->ctrl.baud_x100 = ctrl->baud_x100;
+    }
+
+    if (ctrl->word_length <= UART_WORD_LEN_MAX_VALUE) {
+        ctx->ctrl.word_length = ctrl->word_length;
     }
 
     if (ctrl->parity <= UART_PARITY_MAX_VALUE) {

--- a/src/uart-regmap.c
+++ b/src/uart-regmap.c
@@ -235,8 +235,8 @@ void uart_regmap_process_irq(const struct uart_descr *u)
         rx_data.byte = u->uart->RDR;
         // 7e, 7o, 7n modes need zeroing MSB bit in received byte:
         // STM32 can also obtain 6e, 6o and 9n modes, but we dont use it in our software.
-        if ((u->uart->CR1 & (USART_CR1_M | USART_CR1_PCE) == USART_CR1_PCE) || // 7e, 7o modes
-           (u->uart->CR1 & USART_CR1_M == USART_CR1_M1)) {  // 7n mode
+        if (((u->uart->CR1 & (USART_CR1_M | USART_CR1_PCE)) == USART_CR1_PCE) || // 7e, 7o modes
+           ((u->uart->CR1 & USART_CR1_M) == USART_CR1_M1)) {  // 7n mode
             rx_data.byte &= 0x7F;
         }
         // максимально быстро считываем флаги ошибок и сбрасываем их, разгребем потом


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Необходимо научить wbec и его драйвер на linux работе uart в режиме 7e1.
[Связанный PR в linux](https://github.com/wirenboard/linux/pull/345)

___________________________________
**Что поменялось для пользователей:**
Появится возможность подключения через MOD1 и MOD2 на WB8.5 к счётчикам компании "Энергомера", которые требуют работы в режиме 7e1, это изначальная цель тикета. Но так же появляется возможность подключаться через MOD1 и MOD2 и к другим устройствам, которые требуют форматы 7n, 7e, 7o. Раньше через эти порты можно было общаться только в режимах 8n, 8e, 8o.

___________________________________
**Как проверял/а:**
Вначале на столе разработчика, замкнув в петлю MOD1 на MOD2. Потом на стенде со счётчиками:
https://wirenboard.cloud/organizations/ebd1a3f3-5870-4572-8072-8261d94b334c/controllers/AOFJTE5
В 7-битном режиме общаются счётчики CE102M и CE301.
Так же проверил что не ломается совместимость с нашими модулями на стенде с парой WB M1W2 v.3 по одному на MOD1 и MOD2.:
https://wirenboard.cloud/organizations/ebd1a3f3-5870-4572-8072-8261d94b334c/controllers/AI34KN7B

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
Изменения достаточно малы и касаются напрямую регистров харда, обычно такое проверяется на железе.

