### PR TITLE
add internal vbat charging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-ec-firmware (2.1.2) stable; urgency=medium
+
+  * add VBAT charging
+
+ -- Nikolay Oleinik <nikolay.oleinik@wirenboard.com>  Sun, 19 Apr 2026 15:29:00 +0700
+
 wb-ec-firmware (2.1.1) stable; urgency=medium
 
   * add environment for unittests and coverage metering

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
-wb-ec-firmware (2.1.2) stable; urgency=medium
+wb-ec-firmware (2.2.0) stable; urgency=medium
 
   * add VBAT charging
+  * add VBAT voltage to regmap
+  * add VBAT charging status to regmap
 
  -- Nikolay Oleinik <nikolay.oleinik@wirenboard.com>  Sun, 19 Apr 2026 15:29:00 +0700
 

--- a/include/adc.h
+++ b/include/adc.h
@@ -34,6 +34,7 @@ enum adc_vref {
 
 void adc_init(enum adc_clock clock_divider, enum adc_vref vref);
 void adc_set_lowpass_rc(enum adc_channel channel, uint16_t rc_ms);
+void adc_reset_lowpass(enum adc_channel channel);
 void adc_set_offset_mv(enum adc_channel channel, int16_t offset_mv);
 fix16_t adc_get_ch_adc_raw(enum adc_channel channel);
 int32_t adc_get_ch_mv(enum adc_channel channel);

--- a/include/config_wb74.h
+++ b/include/config_wb74.h
@@ -66,19 +66,20 @@
 #define ADC_V_IN_DIODE_DROP_MV                  400
 
 #define ADC_CHANNELS_DESC(macro) \
-        /*    Channel name          ADC CH  PORT    PIN     RC      K              */ \
-        macro(ADC_IN1,              10,     GPIOB,  2,      50,     1               ) \
-        macro(ADC_IN2,              11,     GPIOB,  10,     50,     1               ) \
-        macro(ADC_IN3,              15,     GPIOB,  11,     50,     1               ) \
-        macro(ADC_IN4,              16,     GPIOB,  12,     50,     1               ) \
-        macro(ADC_V_IN,             9,      GPIOB,  1,      10,     212.0 / 12.0    ) \
-        macro(ADC_5V,               8,      GPIOB,  0,      10,     22.0 / 10.0     ) \
-        macro(ADC_3V3,              7,      GPIOA,  7,      10,     32.0 / 22.0     ) \
-        macro(ADC_NTC,              6,      GPIOA,  6,      50,     1               ) \
-        macro(ADC_VBUS_DEBUG,       3,      GPIOA,  3,      10,     2.2 / 1.0       ) \
-        macro(ADC_VBUS_NETWORK,     5,      GPIOA,  5,      10,     2.2 / 1.0       ) \
-        macro(ADC_HW_VER,           17,     GPIOA,  13,     50,     1               ) \
-        macro(ADC_INT_VREF,         13,     0,      0,      50,     1               ) \
+        /*    Channel name          ADC CH  PORT                  PIN                   RC      K              */ \
+        macro(ADC_IN1,              10,     GPIOB,                2,                    50,     1               ) \
+        macro(ADC_IN2,              11,     GPIOB,                10,                   50,     1               ) \
+        macro(ADC_IN3,              15,     GPIOB,                11,                   50,     1               ) \
+        macro(ADC_IN4,              16,     GPIOB,                12,                   50,     1               ) \
+        macro(ADC_V_IN,             9,      GPIOB,                1,                    10,     212.0 / 12.0    ) \
+        macro(ADC_5V,               8,      GPIOB,                0,                    10,     22.0 / 10.0     ) \
+        macro(ADC_3V3,              7,      GPIOA,                7,                    10,     32.0 / 22.0     ) \
+        macro(ADC_NTC,              6,      GPIOA,                6,                    50,     1               ) \
+        macro(ADC_VBUS_DEBUG,       3,      GPIOA,                3,                    10,     2.2 / 1.0       ) \
+        macro(ADC_VBUS_NETWORK,     5,      GPIOA,                5,                    10,     2.2 / 1.0       ) \
+        macro(ADC_HW_VER,           17,     GPIOA,                13,                   50,     1               ) \
+        macro(ADC_INT_VREF,         13,     ADC_NO_GPIO_PIN,      ADC_NO_GPIO_PIN,      50,     1               ) \
+        macro(ADC_INT_VBAT,         14,     ADC_NO_GPIO_PIN,      ADC_NO_GPIO_PIN,      10,     3.0             ) \
 
 // macro(ADC_HW_VER,           17,      GPIOA,  13,     50,     1,              0           )
 

--- a/include/config_wb85.h
+++ b/include/config_wb85.h
@@ -117,19 +117,20 @@
 #define ADC_V_IN_DIODE_DROP_MV                  400
 
 #define ADC_CHANNELS_DESC(macro) \
-        /*    Channel name          ADC CH  PORT    PIN     RC      K              */ \
-        macro(ADC_IN1,              10,     GPIOB,  2,      50,     1               ) \
-        macro(ADC_IN2,              11,     GPIOB,  10,     50,     1               ) \
-        macro(ADC_IN3,              15,     GPIOB,  11,     50,     1               ) \
-        macro(ADC_IN4,              16,     GPIOB,  12,     50,     1               ) \
-        macro(ADC_V_IN,             9,      GPIOB,  1,      10,     212.0 / 12.0    ) \
-        macro(ADC_5V,               8,      GPIOB,  0,      10,     22.0 / 10.0     ) \
-        macro(ADC_3V3,              6,      GPIOA,  6,      10,     32.0 / 22.0     ) \
-        macro(ADC_NTC,              5,      GPIOA,  5,      50,     1               ) \
-        macro(ADC_VBUS_DEBUG,       3,      GPIOA,  3,      10,     2.2 / 1.0       ) \
-        macro(ADC_VBAT,             7,      GPIOA,  7,      10,     200.0 / 100.0   ) \
-        macro(ADC_HW_VER,           17,     GPIOA,  13,     50,     1               ) \
-        macro(ADC_INT_VREF,         13,     0,      0,      50,     1               ) \
+        /*    Channel name          ADC CH  PORT                  PIN                   RC      K              */ \
+        macro(ADC_IN1,              10,     GPIOB,                2,                    50,     1               ) \
+        macro(ADC_IN2,              11,     GPIOB,                10,                   50,     1               ) \
+        macro(ADC_IN3,              15,     GPIOB,                11,                   50,     1               ) \
+        macro(ADC_IN4,              16,     GPIOB,                12,                   50,     1               ) \
+        macro(ADC_V_IN,             9,      GPIOB,                1,                    10,     212.0 / 12.0    ) \
+        macro(ADC_5V,               8,      GPIOB,                0,                    10,     22.0 / 10.0     ) \
+        macro(ADC_3V3,              6,      GPIOA,                6,                    10,     32.0 / 22.0     ) \
+        macro(ADC_NTC,              5,      GPIOA,                5,                    50,     1               ) \
+        macro(ADC_VBUS_DEBUG,       3,      GPIOA,                3,                    10,     2.2 / 1.0       ) \
+        macro(ADC_VBAT,             7,      GPIOA,                7,                    10,     200.0 / 100.0   ) \
+        macro(ADC_HW_VER,           17,     GPIOA,                13,                   50,     1               ) \
+        macro(ADC_INT_VREF,         13,     ADC_NO_GPIO_PIN,      ADC_NO_GPIO_PIN,      50,     1               ) \
+        macro(ADC_INT_VBAT,         14,     ADC_NO_GPIO_PIN,      ADC_NO_GPIO_PIN,      10,     3.0             ) \
 
 // Ожидание после старта прошивки и перед опросом напряжений
 // Должно быть около 10RC канала ADC_5V

--- a/include/mcu-pwr.h
+++ b/include/mcu-pwr.h
@@ -20,3 +20,4 @@ enum mcu_poweron_reason mcu_get_poweron_reason(void);
 void mcu_goto_standby(uint16_t wakeup_after_s);
 enum mcu_vcc_5v_state mcu_get_vcc_5v_last_state(void);
 void mcu_save_vcc_5v_last_state(enum mcu_vcc_5v_state state);
+void mcu_check_vbat_do_periodic_work(void);

--- a/include/mcu-vbat.h
+++ b/include/mcu-vbat.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void mcu_vbat_init(void);
+void mcu_vbat_check_do_periodic_work(void);

--- a/include/mcu-vbat.h
+++ b/include/mcu-vbat.h
@@ -2,3 +2,11 @@
 
 void mcu_vbat_init(void);
 void mcu_vbat_check_do_periodic_work(void);
+
+// Триггерит внеочередное измерение Vbat из состояния IDLE.
+// Если сейчас идёт зарядка (CHARGING) - вызов игнорируется.
+void mcu_vbat_trigger_measurement(void);
+
+// Перезапускает алгоритм зарядки: включает PWR_CR4_VBE и сбрасывает
+// таймер зарядки на полный цикл.
+void mcu_vbat_restart_charging(void);

--- a/include/mcu-vbat.h
+++ b/include/mcu-vbat.h
@@ -3,8 +3,7 @@
 void mcu_vbat_init(void);
 void mcu_vbat_check_do_periodic_work(void);
 
-// Триггерит внеочередное измерение Vbat из состояния IDLE.
-// Если сейчас идёт зарядка (CHARGING) - вызов игнорируется.
+// Триггерит внеочередное измерение Vbat
 void mcu_vbat_trigger_measurement(void);
 
 // Перезапускает алгоритм зарядки: включает PWR_CR4_VBE и сбрасывает

--- a/include/regmap-structs.h
+++ b/include/regmap-structs.h
@@ -63,11 +63,6 @@
         /* 0x49 */  uint16_t v_a4; \
     ) \
     /*     Addr     Name            RO/RW */ \
-    m(     0x50,    VBAT_STATUS,    RO, \
-        /* 0x50 */  uint16_t voltage_mv; \
-        /* 0x51 */  uint16_t is_charging : 1; \
-    ) \
-    /*     Addr     Name            RO/RW */ \
     m(     0x80,    GPIO_CTRL,      RW, \
         /* 0x80 */  uint16_t gpio_ctrl; \
     ) \
@@ -140,6 +135,11 @@
         /* 0xD2 */  uint16_t enabled : 1; \
     ) \
     /*     Addr     Name            RO/RW */ \
+    m(     0xE0,    VBAT_STATUS,    RO, \
+        /* 0xE0 */  uint16_t voltage_mv; \
+        /* 0xE1 */  uint16_t is_charging : 1; \
+    ) \
+    /*     Addr     Name            RO/RW */ \
     m(     0xF0,    TEST,           RW, \
         /* 0xF0 */  uint16_t send_test_message : 1; \
         /* 0xF0 */  uint16_t enable_rtc_out : 1; \
@@ -148,6 +148,8 @@
         /* 0xF0 */  uint16_t wbmz_force_control : 1; \
         /* 0xF0 */  uint16_t wbmz_stepup_en : 1; \
         /* 0xF0 */  uint16_t wbmz_charge_en : 1; \
+        /* 0xF0 */  uint16_t vbat_meas_en : 1; \
+        /* 0xF0 */  uint16_t vbat_charge_en : 1; \
     ) \
     /* UARTs */ \
     /*     Addr     Name            RO/RW */ \

--- a/include/regmap-structs.h
+++ b/include/regmap-structs.h
@@ -63,6 +63,11 @@
         /* 0x49 */  uint16_t v_a4; \
     ) \
     /*     Addr     Name            RO/RW */ \
+    m(     0x50,    VBAT_STATUS,    RO, \
+        /* 0x50 */  uint16_t voltage_mv; \
+        /* 0x51 */  uint16_t is_charging : 1; \
+    ) \
+    /*     Addr     Name            RO/RW */ \
     m(     0x80,    GPIO_CTRL,      RW, \
         /* 0x80 */  uint16_t gpio_ctrl; \
     ) \

--- a/src/adc.c
+++ b/src/adc.c
@@ -231,6 +231,16 @@ void adc_set_lowpass_rc(enum adc_channel channel, uint16_t rc_ms)
     adc_ctx.lowpass_factors[ch_index_in_dma_buff] = calculate_rc_factor(rc_ms);
 }
 
+// Сбрасывает lowpass фильтр канала, защёлкивая в нём текущее raw значение из DMA-буфера.
+// Используется, когда канал был временно отключён (например, через ADC_CCR_VBATEN)
+// и накопленное значение фильтра уже не актуально.
+void adc_reset_lowpass(enum adc_channel channel)
+{
+    uint8_t ch_index_in_dma_buff = ADC_CHANNEL_INDEX(channel);
+
+    adc_ctx.lowpass_values[ch_index_in_dma_buff] = fix16_from_int(adc_ctx.raw_values[ch_index_in_dma_buff]);
+}
+
 void adc_set_offset_mv(enum adc_channel channel, int16_t offset_mv)
 {
     adc_ctx.offset_mv[channel] = offset_mv;

--- a/src/main.c
+++ b/src/main.c
@@ -25,6 +25,7 @@
 #include "software_i2c.h"
 #include "uart-regmap-subsystem.h"
 #include "wdt-stm32.h"
+#include "mcu-vbat.h"
 
 int main(void)
 {
@@ -81,6 +82,8 @@ int main(void)
     systick_init();
     adc_init(ADC_CLOCK_DIV_64, ADC_VREF_INT);
 
+    mcu_vbat_init();
+
     // Init drivers
     gpio_init();
     temperature_control_init();
@@ -113,7 +116,6 @@ int main(void)
         irq_do_periodic_work();
         vmon_do_periodic_work();
         test_do_periodic_work();
-        mcu_check_vbat_do_periodic_work();
         buzzer_subsystem_do_periodic_work();
         wbmz_subsystem_do_periodic_work();
 
@@ -124,6 +126,8 @@ int main(void)
         // Main algorithm
         linux_cpu_pwr_seq_do_periodic_work();
         wbec_do_periodic_work();
+
+        mcu_vbat_check_do_periodic_work();
 
         watchdog_reload();
     }

--- a/src/main.c
+++ b/src/main.c
@@ -113,6 +113,7 @@ int main(void)
         irq_do_periodic_work();
         vmon_do_periodic_work();
         test_do_periodic_work();
+        mcu_check_vbat_do_periodic_work();
         buzzer_subsystem_do_periodic_work();
         wbmz_subsystem_do_periodic_work();
 

--- a/src/mcu-pwr.c
+++ b/src/mcu-pwr.c
@@ -2,14 +2,8 @@
 #include "config.h"
 #include "wbmcu_system.h"
 #include "rtc.h"
-#include "adc.h"
-#include "systick.h"
-
-#define VBAT_THRESHOLD_MV               3000
-#define VBAT_CHARGING_TIME_MS           (2*24*3600*1000) // 2 days
 
 static enum mcu_poweron_reason mcu_poweron_reason = MCU_POWERON_REASON_UNKNOWN;
-static systime_t vbat_charging_start_timestamp;
 
 // Вызывать один раз в начале main
 void mcu_init_poweron_reason(void)
@@ -30,8 +24,6 @@ void mcu_init_poweron_reason(void)
     } else {
         mcu_poweron_reason = MCU_POWERON_REASON_POWER_ON;
     }
-
-    PWR->CR4 |= PWR_CR4_VBRS; // enable 1.5 kOhm internal resistor for charging over VBAT
 }
 
 enum mcu_poweron_reason mcu_get_poweron_reason(void)
@@ -80,18 +72,4 @@ enum mcu_vcc_5v_state mcu_get_vcc_5v_last_state(void)
 void mcu_save_vcc_5v_last_state(enum mcu_vcc_5v_state state)
 {
     rtc_save_to_tamper_reg(0, state);
-}
-
-void mcu_check_vbat_do_periodic_work(void)
-{
-    if (PWR->CR4 & PWR_CR4_VBE) {
-        if (systick_get_time_since_timestamp(vbat_charging_start_timestamp) >= VBAT_CHARGING_TIME_MS) {
-            PWR->CR4 &= ~PWR_CR4_VBE;
-        }
-    } else {
-        if (adc_get_ch_mv(ADC_CHANNEL_ADC_INT_VBAT) < VBAT_THRESHOLD_MV) {
-            vbat_charging_start_timestamp = systick_get_system_time_ms();
-            PWR->CR4 |= PWR_CR4_VBE;
-        }
-    }
 }

--- a/src/mcu-pwr.c
+++ b/src/mcu-pwr.c
@@ -2,8 +2,14 @@
 #include "config.h"
 #include "wbmcu_system.h"
 #include "rtc.h"
+#include "adc.h"
+#include "systick.h"
+
+#define VBAT_THRESHOLD_MV               3000
+#define VBAT_CHARGING_TIME_MS           (2*24*3600*1000) // 2 days
 
 static enum mcu_poweron_reason mcu_poweron_reason = MCU_POWERON_REASON_UNKNOWN;
+static systime_t vbat_charging_start_timestamp;
 
 // Вызывать один раз в начале main
 void mcu_init_poweron_reason(void)
@@ -24,6 +30,8 @@ void mcu_init_poweron_reason(void)
     } else {
         mcu_poweron_reason = MCU_POWERON_REASON_POWER_ON;
     }
+
+    PWR->CR4 |= PWR_CR4_VBRS; // enable 1.5 kOhm internal resistor for charging over VBAT
 }
 
 enum mcu_poweron_reason mcu_get_poweron_reason(void)
@@ -72,4 +80,18 @@ enum mcu_vcc_5v_state mcu_get_vcc_5v_last_state(void)
 void mcu_save_vcc_5v_last_state(enum mcu_vcc_5v_state state)
 {
     rtc_save_to_tamper_reg(0, state);
+}
+
+void mcu_check_vbat_do_periodic_work(void)
+{
+    if (PWR->CR4 & PWR_CR4_VBE) {
+        if (systick_get_time_since_timestamp(vbat_charging_start_timestamp) >= VBAT_CHARGING_TIME_MS) {
+            PWR->CR4 &= ~PWR_CR4_VBE;
+        }
+    } else {
+        if (adc_get_ch_mv(ADC_CHANNEL_ADC_INT_VBAT) < VBAT_THRESHOLD_MV) {
+            vbat_charging_start_timestamp = systick_get_system_time_ms();
+            PWR->CR4 |= PWR_CR4_VBE;
+        }
+    }
 }

--- a/src/mcu-vbat.c
+++ b/src/mcu-vbat.c
@@ -26,7 +26,11 @@ static inline void update_regmap(void)
 {
     struct REGMAP_VBAT_STATUS r;
     r.voltage_mv = vbat_mv;
-    r.is_charging = (PWR->CR4 & PWR_CR4_VBE) ? 1 : 0;
+    if (PWR->CR4 & PWR_CR4_VBE) {
+        r.is_charging = 1;
+    } else {
+        r.is_charging = 0;
+    }
     regmap_set_region_data(REGMAP_REGION_VBAT_STATUS, &r, sizeof(r));
 }
 
@@ -66,7 +70,6 @@ void mcu_vbat_check_do_periodic_work(void)
         vbat_mv = adc_get_ch_mv(ADC_CHANNEL_ADC_INT_VBAT);
         ADC->CCR &= ~ADC_CCR_VBATEN;
         vbat_state_timestamp = systick_get_system_time_ms();
-        update_regmap();
 
         if (vbat_mv < VBAT_THRESHOLD_MV) {
             PWR->CR4 |= PWR_CR4_VBE;
@@ -84,4 +87,6 @@ void mcu_vbat_check_do_periodic_work(void)
         }
         break;
     }
+
+    update_regmap();
 }

--- a/src/mcu-vbat.c
+++ b/src/mcu-vbat.c
@@ -1,0 +1,87 @@
+#include "mcu-vbat.h"
+#include "config.h"
+#include "wbmcu_system.h"
+#include "adc.h"
+#include "systick.h"
+#include "fix16.h"
+#include "regmap-int.h"
+
+#define VBAT_THRESHOLD_MV               3000
+#define VBAT_ADC_MEAS_PERIOD_MS         (1*24*3600*1000)    // 1 день между измерениями
+#define VBAT_CHARGING_TIME_MS           (2*24*3600*1000)    // 2 дня длительность зарядки
+// Время на стабилизацию делителя VBAT и набор свежего значения в DMA-буфере
+#define VBAT_MEAS_STABILIZE_MS          30
+
+enum vbat_state {
+    VBAT_STATE_IDLE,        // ждём очередного периода измерения
+    VBAT_STATE_MEASURING,   // делитель VBAT включён, ждём стабилизации
+    VBAT_STATE_CHARGING,    // PWR_CR4_VBE включён, идёт зарядка
+};
+
+static enum vbat_state vbat_state;
+static systime_t vbat_state_timestamp;
+static int32_t vbat_mv;
+
+static inline void update_regmap(void)
+{
+    struct REGMAP_VBAT_STATUS r;
+    r.voltage_mv = vbat_mv;
+    r.is_charging = (PWR->CR4 & PWR_CR4_VBE) ? 1 : 0;
+    regmap_set_region_data(REGMAP_REGION_VBAT_STATUS, &r, sizeof(r));
+}
+
+void mcu_vbat_init(void)
+{
+    PWR->CR4 |= PWR_CR4_VBRS;   // для зарядки выбираем резистор 1.5 кОм, т.к. последовательно есть еще аппаратный резистор 3кОм
+    vbat_state = VBAT_STATE_IDLE;
+    // Установим timestamp так, чтобы первое измерение произошло сразу при включении
+    vbat_state_timestamp = systick_get_system_time_ms() - VBAT_ADC_MEAS_PERIOD_MS;
+}
+
+void mcu_vbat_check_do_periodic_work(void)
+{
+    switch (vbat_state) {
+    case VBAT_STATE_IDLE:
+        if (systick_get_time_since_timestamp(vbat_state_timestamp) < VBAT_ADC_MEAS_PERIOD_MS) {
+            break;
+        }
+        if (!adc_get_ready()) {
+            break;
+        }
+        // Включаем встроенный делитель VBAT/3. Канал 14 уже сидит в DMA-списке,
+        // АЦП конвертит его постоянно — теперь будет писать в raw_values реальное
+        // значение батарейки.
+        ADC->CCR |= ADC_CCR_VBATEN;
+        vbat_state_timestamp = systick_get_system_time_ms();
+        vbat_state = VBAT_STATE_MEASURING;
+        break;
+
+    case VBAT_STATE_MEASURING:
+        if (systick_get_time_since_timestamp(vbat_state_timestamp) < VBAT_MEAS_STABILIZE_MS) {
+            break;
+        }
+        // Защёлкиваем свежее raw в lowpass (иначе фильтр содержит мусор от
+        // выключенного делителя), читаем mV, выключаем делитель для экономии батареи.
+        adc_reset_lowpass(ADC_CHANNEL_ADC_INT_VBAT);
+        vbat_mv = adc_get_ch_mv(ADC_CHANNEL_ADC_INT_VBAT);
+        ADC->CCR &= ~ADC_CCR_VBATEN;
+        vbat_state_timestamp = systick_get_system_time_ms();
+        update_regmap();
+
+        if (vbat_mv < VBAT_THRESHOLD_MV) {
+            PWR->CR4 |= PWR_CR4_VBE;
+            vbat_state = VBAT_STATE_CHARGING;
+        } else {
+            vbat_state = VBAT_STATE_IDLE;
+        }
+        break;
+
+    case VBAT_STATE_CHARGING:
+        if (systick_get_time_since_timestamp(vbat_state_timestamp) >= VBAT_CHARGING_TIME_MS) {
+            PWR->CR4 &= ~PWR_CR4_VBE;
+            vbat_state_timestamp = systick_get_system_time_ms();
+            vbat_state = VBAT_STATE_IDLE;
+        }
+        break;
+    }
+}

--- a/src/mcu-vbat.c
+++ b/src/mcu-vbat.c
@@ -5,6 +5,7 @@
 #include "systick.h"
 #include "fix16.h"
 #include "regmap-int.h"
+#include <stdbool.h>
 
 #define VBAT_THRESHOLD_MV               3000
 #define VBAT_ADC_MEAS_PERIOD_MS         (1*24*3600*1000)    // 1 день между измерениями
@@ -22,11 +23,30 @@ static enum vbat_state vbat_state;
 static systime_t vbat_state_timestamp;
 static int32_t vbat_mv;
 
+static inline void start_charge(void)
+{
+    PWR->CR4 |= PWR_CR4_VBE;
+}
+
+static inline void stop_charge(void)
+{
+    PWR->CR4 &= ~PWR_CR4_VBE;
+}
+
+static inline bool is_charging(void)
+{
+    if (PWR->CR4 & PWR_CR4_VBE) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 static inline void update_regmap(void)
 {
     struct REGMAP_VBAT_STATUS r;
     r.voltage_mv = vbat_mv;
-    if (PWR->CR4 & PWR_CR4_VBE) {
+    if (is_charging()) {
         r.is_charging = 1;
     } else {
         r.is_charging = 0;
@@ -56,6 +76,8 @@ void mcu_vbat_check_do_periodic_work(void)
         // АЦП конвертит его постоянно — теперь будет писать в raw_values реальное
         // значение батарейки.
         ADC->CCR |= ADC_CCR_VBATEN;
+        // Защёлкиваем последнее raw в lowpass (иначе фильтр содержит мусор от выключенного делителя)
+        adc_reset_lowpass(ADC_CHANNEL_ADC_INT_VBAT);
         vbat_state_timestamp = systick_get_system_time_ms();
         vbat_state = VBAT_STATE_MEASURING;
         break;
@@ -64,15 +86,13 @@ void mcu_vbat_check_do_periodic_work(void)
         if (systick_get_time_since_timestamp(vbat_state_timestamp) < VBAT_MEAS_STABILIZE_MS) {
             break;
         }
-        // Защёлкиваем свежее raw в lowpass (иначе фильтр содержит мусор от
-        // выключенного делителя), читаем mV, выключаем делитель для экономии батареи.
-        adc_reset_lowpass(ADC_CHANNEL_ADC_INT_VBAT);
+        // читаем mV, выключаем делитель для экономии батареи
         vbat_mv = adc_get_ch_mv(ADC_CHANNEL_ADC_INT_VBAT);
         ADC->CCR &= ~ADC_CCR_VBATEN;
         vbat_state_timestamp = systick_get_system_time_ms();
 
         if (vbat_mv < VBAT_THRESHOLD_MV) {
-            PWR->CR4 |= PWR_CR4_VBE;
+            start_charge();
             vbat_state = VBAT_STATE_CHARGING;
         } else {
             vbat_state = VBAT_STATE_IDLE;
@@ -81,7 +101,7 @@ void mcu_vbat_check_do_periodic_work(void)
 
     case VBAT_STATE_CHARGING:
         if (systick_get_time_since_timestamp(vbat_state_timestamp) >= VBAT_CHARGING_TIME_MS) {
-            PWR->CR4 &= ~PWR_CR4_VBE;
+            stop_charge();
             vbat_state_timestamp = systick_get_system_time_ms();
             vbat_state = VBAT_STATE_IDLE;
         }
@@ -89,4 +109,21 @@ void mcu_vbat_check_do_periodic_work(void)
     }
 
     update_regmap();
+}
+
+void mcu_vbat_trigger_measurement(void)
+{
+    // Принудительно прерываем текущее состояние (в т.ч. зарядку) и запускаем
+    // измерение немедленно: переходим в IDLE с уже истекшим периодом,
+    // ближайший do_periodic_work запустит измерение.
+    stop_charge();
+    vbat_state_timestamp = systick_get_system_time_ms() - VBAT_ADC_MEAS_PERIOD_MS;
+    vbat_state = VBAT_STATE_IDLE;
+}
+
+void mcu_vbat_restart_charging(void)
+{
+    start_charge();
+    vbat_state_timestamp = systick_get_system_time_ms();
+    vbat_state = VBAT_STATE_CHARGING;
 }

--- a/src/test_subsystem.c
+++ b/src/test_subsystem.c
@@ -4,6 +4,7 @@
 #include "rtc.h"
 #include "temperature-control.h"
 #include "wbmz-common.h"
+#include "mcu-vbat.h"
 
 /**
  * Выполняет разные тестовые функции, в обычной работе не участвует.
@@ -44,6 +45,16 @@ void test_do_periodic_work(void)
 
         wbmz_set_charging_force_control(test.wbmz_force_control, test.wbmz_charge_en);
         wbmz_set_stepup_force_control(test.wbmz_force_control, test.wbmz_stepup_en);
+
+        if (test.vbat_meas_en) {
+            mcu_vbat_trigger_measurement();
+            test.vbat_meas_en = 0;
+        }
+
+        if (test.vbat_charge_en) {
+            mcu_vbat_restart_charging();
+            test.vbat_charge_en = 0;
+        }
 
         regmap_set_region_data(REGMAP_REGION_TEST, &test, sizeof(test));
     }

--- a/system/build_common.mk
+++ b/system/build_common.mk
@@ -158,8 +158,8 @@ $(TARGET_DIR)/$(TARGET).elf: version_check $(OBJECTS) $(LD_FILES) $(TARGET_DIR)/
 	$(SZ) $@
 	@echo
 
-$(TARGET_DIR)/stack_size.ld:
-	$(shell echo "_Minimum_Stack_Size = $(STACK_SIZE);" > $@)
+$(TARGET_DIR)/stack_size.ld: | $(TARGET_DIR)
+	echo "_Minimum_Stack_Size = $(STACK_SIZE);" > $@
 
 $(TARGET_DIR)/%.hex: $(TARGET_DIR)/%.elf
 	$(HEX) $< $@


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Согласно схеме у нас на диоде падает напряжение с 3,3 до 2,6В, это напряжение не может заряжать мелкий часовой аккум. Решили включать дополнительно зарядку с помощью VBAT с самой стмки. Заряжает через внутренний 1,5 кОм резистор (есть еще 5 кОм, но т.к. у нас последовательно стоит еще 3 кОм, то 1,5 оптимально). Алгоритм простой: проверяем напряжение на пине VBAT, если меньше 3В, то включаем зарядку на двое суток (ток мелкий + особенности аккума), периодически повторяем. 

___________________________________
**Что поменялось для пользователей:**
часовой аккум будет подзаряжаться

___________________________________
**Как проверял/а:**
_Проверка должна быть добавлена в таблицу_ [_Проверка устройств_](https://docs.google.com/spreadsheets/d/1eM_yCI9u0sRpEqWSB27-3WJBhpaoL-3roIDQObEudFc/edit?gid=759809447#gid=759809447)

на столе осциллом
___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
_См._ [_Юнит-тесты модулей прошивок микроконтроллеров_](https://docs.google.com/document/d/1u1pAsO4--ouo3O7azLobLfE3LtHVDF7L_p9FcmntPJE/edit?tab=t.0#heading=h.7u9a12aw3f2n)

не требуется