### PR TITLE
Fix/vbat treshold

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-ec-firmware (2.2.1) stable; urgency=medium
 
   * fix VBAT treshold
 
- -- Nikolay Oleinik <nikolay.oleinik@wirenboard.com>  Sun, 08 Apr 2026 15:07:00 +0700
+ -- Nikolay Oleinik <nikolay.oleinik@wirenboard.com>  Fri, 08 May 2026 15:07:00 +0700
 
 wb-ec-firmware (2.2.0) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-ec-firmware (2.2.1) stable; urgency=medium
+
+  * fix VBAT treshold
+
+ -- Nikolay Oleinik <nikolay.oleinik@wirenboard.com>  Sun, 08 Apr 2026 15:07:00 +0700
+
 wb-ec-firmware (2.2.0) stable; urgency=medium
 
   * add VBAT charging

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-ec-firmware (2.3.1) stable; urgency=medium
 
   * fix VBAT treshold
+  * change VBAT_MEAS_STABILIZE_MS to 100 ms
 
  -- Nikolay Oleinik <nikolay.oleinik@wirenboard.com>  Mon, 22 Jun 2026 19:07:00 +0700
 

--- a/src/mcu-vbat.c
+++ b/src/mcu-vbat.c
@@ -11,7 +11,7 @@
 #define VBAT_ADC_MEAS_PERIOD_MS         (1*24*3600*1000)    // 1 день между измерениями
 #define VBAT_CHARGING_TIME_MS           (2*24*3600*1000)    // 2 дня длительность зарядки
 // Время на стабилизацию делителя VBAT и набор свежего значения в DMA-буфере
-#define VBAT_MEAS_STABILIZE_MS          30
+#define VBAT_MEAS_STABILIZE_MS          100
 
 enum vbat_state {
     VBAT_STATE_IDLE,        // ждём очередного периода измерения

--- a/src/mcu-vbat.c
+++ b/src/mcu-vbat.c
@@ -7,20 +7,32 @@
 #include "regmap-int.h"
 #include <stdbool.h>
 
-#define VBAT_THRESHOLD_MV               2700                // 2.7 В - порог, ниже которого считаем батарейку разряженной и запускаем зарядку
+#define VBAT_THRESHOLD_MV               2850                // 2.85 В - порог, ниже которого считаем батарейку разряженной и запускаем зарядку
 #define VBAT_ADC_MEAS_PERIOD_MS         (1*24*3600*1000)    // 1 день между измерениями
-#define VBAT_CHARGING_TIME_MS           (2*24*3600*1000)    // 2 дня длительность зарядки
+#define VBAT_CHARGING_TIME_MS           (2*3600*1000)       // 2 часа длительность зарядки
 // Время на стабилизацию делителя VBAT и набор свежего значения в DMA-буфере
 #define VBAT_MEAS_STABILIZE_MS          100
+// Пауза после выключения заряда перед измерением
+#define VBAT_RELAX_TIME_MS              (5*60*1000)         // 5 минут
 
 enum vbat_state {
     VBAT_STATE_IDLE,        // ждём очередного периода измерения
     VBAT_STATE_MEASURING,   // делитель VBAT включён, ждём стабилизации
     VBAT_STATE_CHARGING,    // PWR_CR4_VBE включён, идёт зарядка
+    VBAT_STATE_RELAX,       // заряд выключен, ждём релаксации перед измерением
 };
 
 static enum vbat_state vbat_state;
-static systime_t vbat_state_timestamp;
+// Якорь суточной сетки: момент последнего измерения. По нему отсчитывается
+// начало следующего суточного интервала (не сдвигается зарядкой).
+static systime_t vbat_meas_timestamp;
+// Момент начала текущей зарядки, для отсчёта её длительности.
+static systime_t vbat_charge_timestamp;
+// Момент включения делителя, для отсчёта времени стабилизации в MEASURING.
+static systime_t vbat_stabilize_timestamp;
+// Измерение сразу после окончания зарядки (для фиксации результата): заряд по
+// его итогам повторно не запускаем, ждём следующего суточного интервала.
+static bool vbat_meas_after_charge;
 static int32_t vbat_mv;
 
 static inline void start_charge(void)
@@ -42,6 +54,24 @@ static inline bool is_charging(void)
     }
 }
 
+// Запускает измерение: включает делитель VBAT/3 и переводит в MEASURING.
+// Возвращает false, если АЦП ещё не готов (нужно повторить попытку позже).
+static bool start_measurement(void)
+{
+    if (!adc_get_ready()) {
+        return false;
+    }
+    // Включаем встроенный делитель VBAT/3. Канал 14 уже сидит в DMA-списке,
+    // АЦП конвертит его постоянно — теперь будет писать в raw_values реальное
+    // значение батарейки.
+    ADC->CCR |= ADC_CCR_VBATEN;
+    // Защёлкиваем последнее raw в lowpass (иначе фильтр содержит мусор от выключенного делителя)
+    adc_reset_lowpass(ADC_CHANNEL_ADC_INT_VBAT);
+    vbat_stabilize_timestamp = systick_get_system_time_ms();
+    vbat_state = VBAT_STATE_MEASURING;
+    return true;
+}
+
 static inline void update_regmap(void)
 {
     struct REGMAP_VBAT_STATUS r;
@@ -59,40 +89,36 @@ void mcu_vbat_init(void)
     PWR->CR4 |= PWR_CR4_VBRS;   // для зарядки выбираем резистор 1.5 кОм, т.к. последовательно есть еще аппаратный резистор 3кОм
     vbat_state = VBAT_STATE_IDLE;
     // Установим timestamp так, чтобы первое измерение произошло сразу при включении
-    vbat_state_timestamp = systick_get_system_time_ms() - VBAT_ADC_MEAS_PERIOD_MS;
+    vbat_meas_timestamp = systick_get_system_time_ms() - VBAT_ADC_MEAS_PERIOD_MS;
 }
 
 void mcu_vbat_check_do_periodic_work(void)
 {
     switch (vbat_state) {
     case VBAT_STATE_IDLE:
-        if (systick_get_time_since_timestamp(vbat_state_timestamp) < VBAT_ADC_MEAS_PERIOD_MS) {
+        if (systick_get_time_since_timestamp(vbat_meas_timestamp) < VBAT_ADC_MEAS_PERIOD_MS) {
             break;
         }
-        if (!adc_get_ready()) {
-            break;
-        }
-        // Включаем встроенный делитель VBAT/3. Канал 14 уже сидит в DMA-списке,
-        // АЦП конвертит его постоянно — теперь будет писать в raw_values реальное
-        // значение батарейки.
-        ADC->CCR |= ADC_CCR_VBATEN;
-        // Защёлкиваем последнее raw в lowpass (иначе фильтр содержит мусор от выключенного делителя)
-        adc_reset_lowpass(ADC_CHANNEL_ADC_INT_VBAT);
-        vbat_state_timestamp = systick_get_system_time_ms();
-        vbat_state = VBAT_STATE_MEASURING;
+        // Якорь суточной сетки ставим на момент начала измерения: следующее
+        // измерение произойдёт ровно через сутки независимо от того, была ли зарядка.
+        vbat_meas_timestamp = systick_get_system_time_ms();
+        vbat_meas_after_charge = false;
+        start_measurement();    // если АЦП не готов, останемся в IDLE и попробуем на след. вызове
         break;
 
     case VBAT_STATE_MEASURING:
-        if (systick_get_time_since_timestamp(vbat_state_timestamp) < VBAT_MEAS_STABILIZE_MS) {
+        if (systick_get_time_since_timestamp(vbat_stabilize_timestamp) < VBAT_MEAS_STABILIZE_MS) {
             break;
         }
         // читаем mV, выключаем делитель для экономии батареи
         vbat_mv = adc_get_ch_mv(ADC_CHANNEL_ADC_INT_VBAT);
         ADC->CCR &= ~ADC_CCR_VBATEN;
-        vbat_state_timestamp = systick_get_system_time_ms();
 
-        if (vbat_mv < VBAT_THRESHOLD_MV) {
+        // После зарядки измеряем только для фиксации результата — заряд повторно
+        // не запускаем, ждём следующего суточного интервала.
+        if ((vbat_mv < VBAT_THRESHOLD_MV) && (!vbat_meas_after_charge)) {
             start_charge();
+            vbat_charge_timestamp = systick_get_system_time_ms();
             vbat_state = VBAT_STATE_CHARGING;
         } else {
             vbat_state = VBAT_STATE_IDLE;
@@ -100,11 +126,25 @@ void mcu_vbat_check_do_periodic_work(void)
         break;
 
     case VBAT_STATE_CHARGING:
-        if (systick_get_time_since_timestamp(vbat_state_timestamp) >= VBAT_CHARGING_TIME_MS) {
+        // Заряжаем 2 часа, затем выключаем заряд и даём батарейке релаксировать
+        // перед контрольным измерением. Следующий суточный интервал отсчитывается
+        // от vbat_meas_timestamp, зарядкой не сдвигается.
+        if (systick_get_time_since_timestamp(vbat_charge_timestamp) >= VBAT_CHARGING_TIME_MS) {
             stop_charge();
-            vbat_state_timestamp = systick_get_system_time_ms();
-            vbat_state = VBAT_STATE_IDLE;
+            // vbat_charge_timestamp переиспользуем как отметку начала релаксации
+            vbat_charge_timestamp = systick_get_system_time_ms();
+            vbat_state = VBAT_STATE_RELAX;
         }
+        break;
+
+    case VBAT_STATE_RELAX:
+        // Ждём стечения поверхностного заряда, затем измеряем для фиксации
+        // результата зарядки (заряд по итогам этого измерения не запускаем).
+        if (systick_get_time_since_timestamp(vbat_charge_timestamp) < VBAT_RELAX_TIME_MS) {
+            break;
+        }
+        vbat_meas_after_charge = true;
+        start_measurement();    // если АЦП не готов, останемся в RELAX и попробуем на след. вызове
         break;
     }
 
@@ -117,13 +157,13 @@ void mcu_vbat_trigger_measurement(void)
     // измерение немедленно: переходим в IDLE с уже истекшим периодом,
     // ближайший do_periodic_work запустит измерение.
     stop_charge();
-    vbat_state_timestamp = systick_get_system_time_ms() - VBAT_ADC_MEAS_PERIOD_MS;
+    vbat_meas_timestamp = systick_get_system_time_ms() - VBAT_ADC_MEAS_PERIOD_MS;
     vbat_state = VBAT_STATE_IDLE;
 }
 
 void mcu_vbat_restart_charging(void)
 {
     start_charge();
-    vbat_state_timestamp = systick_get_system_time_ms();
+    vbat_charge_timestamp = systick_get_system_time_ms();
     vbat_state = VBAT_STATE_CHARGING;
 }

--- a/src/mcu-vbat.c
+++ b/src/mcu-vbat.c
@@ -99,11 +99,11 @@ void mcu_vbat_check_do_periodic_work(void)
         if (systick_get_time_since_timestamp(vbat_meas_timestamp) < VBAT_ADC_MEAS_PERIOD_MS) {
             break;
         }
-        // Якорь суточной сетки ставим на момент начала измерения: следующее
-        // измерение произойдёт ровно через сутки независимо от того, была ли зарядка.
-        vbat_meas_timestamp = systick_get_system_time_ms();
         vbat_meas_after_charge = false;
-        start_measurement();    // если АЦП не готов, останемся в IDLE и попробуем на след. вызове
+        // Якорь суточной сетки сдвигаем ТОЛЬКО если измерение реально стартовало
+        if (start_measurement()) {
+            vbat_meas_timestamp = systick_get_system_time_ms();
+        }
         break;
 
     case VBAT_STATE_MEASURING:

--- a/src/mcu-vbat.c
+++ b/src/mcu-vbat.c
@@ -7,7 +7,7 @@
 #include "regmap-int.h"
 #include <stdbool.h>
 
-#define VBAT_THRESHOLD_MV               3000
+#define VBAT_THRESHOLD_MV               2700                // 2.7 В - порог, ниже которого считаем батарейку разряженной и запускаем зарядку
 #define VBAT_ADC_MEAS_PERIOD_MS         (1*24*3600*1000)    // 1 день между измерениями
 #define VBAT_CHARGING_TIME_MS           (2*24*3600*1000)    // 2 дня длительность зарядки
 // Время на стабилизацию делителя VBAT и набор свежего значения в DMA-буфере


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
обновили порог VBAT на 2700 мВ
увеличил задержу стабилизации программного фильтра, т.к. могли быть старые мусорные значения, из-за которых высчитанное напряжение могло скакать. Нужно для всех для корректного измерения напряжения часовой батарейки
___________________________________
**Что поменялось для пользователей:**
измерение напряжения часовой батарейки теперь стабильнее => стабильнее переход в режим зарядки

___________________________________
**Как проверял/а:**
_Проверка должна быть добавлена в таблицу_ [_Проверка устройств_](https://docs.google.com/spreadsheets/d/1eM_yCI9u0sRpEqWSB27-3WJBhpaoL-3roIDQObEudFc/edit?gid=759809447#gid=759809447)
на столе, собирал данные за час с шагом 1м

___________________________________
**Покрыл/а изменения юниттестом и если нет, то почему:**
_См._ [_Юнит-тесты модулей прошивок микроконтроллеров_](https://docs.google.com/document/d/1u1pAsO4--ouo3O7azLobLfE3LtHVDF7L_p9FcmntPJE/edit?tab=t.0#heading=h.7u9a12aw3f2n)
не требуется
