### PR TITLE
suspend-to-off: Standby heartbeat sleep window (A/B candidate 2)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -65,6 +65,13 @@
 #define WBEC_PERIODIC_WAKEUP_FIRST_TIMEOUT_S    5
 #define WBEC_PERIODIC_WAKEUP_NEXT_TIMEOUT_S     2
 
+// suspend-to-off: период heartbeat-пробуждений (RTC WUT) во время окна сна в
+// STM32 Standby. Каждое пробуждение - это сброс EC, watchdog_init() при
+// загрузке перезапускает IWDG, поэтому окно сна ОБЯЗАНО быть короче периода
+// IWDG (10 с, см. wdt-stm32.h). Это тот же инвариант "EC спит не дольше 5 с",
+// на котором построен обычный poweroff-standby (WBEC_PERIODIC_WAKEUP_*).
+#define WBEC_SUSPEND_STANDBY_HEARTBEAT_S        5
+
 // Число попыток перезапуска PMIC при пропадании 3.3В
 // Если за указанное время 3.3В пропадёт больше, чем указанное число раз,
 // то EC выключит питание и уйдёт в спящий режим

--- a/include/linux-power-control.h
+++ b/include/linux-power-control.h
@@ -4,6 +4,15 @@
 
 void linux_cpu_pwr_seq_init(bool on);
 void linux_cpu_pwr_seq_off_and_goto_standby(uint16_t wakeup_after_s);
+// suspend-to-off: уводит EC в STM32 Standby, ОСТАВЛЯЯ 5В включённым (модульный
+// ключ 5В держит внешняя схема при high-Z пине - PMIC хранит DRAM в
+// self-refresh). Пробуждение (heartbeat WUT / будильник / кнопка) - это сброс
+// EC; его разбирает wbec_init(). Не возвращается.
+void linux_cpu_pwr_seq_suspend_to_standby(uint16_t wakeup_after_s);
+// Пробуждение из suspend-to-off Standby: берёт (держащийся внешней схемой) пин
+// 5В под драйвер без провала уровня и взводит последовательность пробуждения
+// PMIC (импульс PWROK после появления 3.3В). Вызывать один раз из wbec_init.
+void linux_cpu_pwr_seq_resume_init(void);
 void linux_cpu_pwr_seq_on(void);
 void linux_cpu_pwr_seq_wakeup(void);
 void linux_cpu_pwr_seq_hard_off(void);

--- a/include/mcu-pwr.h
+++ b/include/mcu-pwr.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stdbool.h>
 #include "wbmcu_system.h"
 #include "config.h"
 
@@ -21,3 +22,20 @@ void mcu_goto_standby(uint16_t wakeup_after_s);
 enum mcu_vcc_5v_state mcu_get_vcc_5v_last_state(void);
 void mcu_save_vcc_5v_last_state(enum mcu_vcc_5v_state state);
 void mcu_check_vbat_do_periodic_work(void);
+
+// --- suspend-to-off: состояние окна сна в backup-домене RTC/TAMP ---
+// Во время окна suspend-to-off EC спит в STM32 Standby (как в poweroff).
+// Standby стирает SRAM, поэтому факт "EC спит в окне suspend-to-off" и остаток
+// дедлайна живут в backup-регистрах TAMP: они питаются от VBAT и переживают
+// Standby-сброс. Регистр 0 занят состоянием 5В (mcu_save_vcc_5v_last_state).
+
+// Взводит метку suspend-to-off и сохраняет остаток дедлайна (в секундах)
+// перед входом в Standby.
+void mcu_suspend_arm(uint32_t remaining_deadline_s);
+// Потребляет метку на пробуждении-сбросе: true ровно один раз, если этот
+// сброс - выход из Standby со взведённой меткой. Метка стирается безусловно:
+// метка, пережившая обесточивание (её хранит VBAT), не должна быть позже
+// ошибочно прочитана как resume на обычном пробуждении из Standby.
+bool mcu_suspend_take_resume(void);
+// Остаток дедлайна (в секундах), сохранённый mcu_suspend_arm() перед сном.
+uint32_t mcu_suspend_get_remaining_s(void);

--- a/src/linux-power-control.c
+++ b/src/linux-power-control.c
@@ -126,6 +126,99 @@ void linux_cpu_pwr_seq_off_and_goto_standby(uint16_t wakeup_after_s)
     mcu_goto_standby(wakeup_after_s);
 }
 
+// Подтяжка пина на время Standby (применяется по PWR_CR3_APC). В Standby
+// драйверы GPIO выключены и уровень пина задаётся только PWR->PUCRx/PDCRx.
+static void standby_pull(const gpio_pin_t * gpio, bool up)
+{
+    volatile uint32_t * reg;
+    if (gpio->port == GPIOA) {
+        reg = up ? &PWR->PUCRA : &PWR->PDCRA;
+    } else if (gpio->port == GPIOB) {
+        reg = up ? &PWR->PUCRB : &PWR->PDCRB;
+    } else if (gpio->port == GPIOD) {
+        reg = up ? &PWR->PUCRD : &PWR->PDCRD;
+    } else {
+        return; // GCOVR_EXCL_LINE
+    }
+    *reg |= (1u << gpio->pin);
+}
+
+/**
+ * @brief suspend-to-off: усыпляет EC в STM32 Standby на heartbeat-интервал.
+ *
+ * Отличие от linux_cpu_pwr_seq_off_and_goto_standby: там пин 5В подтягивают
+ * ВНИЗ (линукс должен остаться выключенным). Здесь 5В ДОЛЖНО остаться
+ * включённым весь сон - PMIC хранит DRAM в self-refresh. Для этого пин 5В
+ * (EC_GPIO_LINUX_POWER) НАРОЧНО оставляется ВООБЩЕ БЕЗ подтяжки (high-Z):
+ * по схеме WB 8.5.3 ключ 5В модуля (U14 SY6280) держится ВКЛЮЧЁННЫМ внешним
+ * резистором R38 470k -> +5V/1; EC выключает его, только активно прижимая EN
+ * через R37 10k. C32 2.2 мкФ на EN (tau ~ 1 с) сглаживает и короткие окна
+ * сброса при heartbeat-пробуждениях. Никакого раннего перехвата пина или
+ * внутренней подтяжки не требуется - 5В держит железо.
+ * ВАЖНО: подтяжку ВНИЗ на пин 5В здесь ставить нельзя - это выключит ключ,
+ * DRAM выпадет из self-refresh и resume станет невозможен.
+ *
+ * PWRON и PWROK/RESET при high-Z и так неактивны (NPN-BRT с внутренним
+ * резистором база-эмиттер держит транзистор закрытым); подтяжки вниз - только
+ * страховка от наводок на длинном окне.
+ *
+ * Кнопка питания (PA0) уже настроена как WKUP с подтяжкой вверх в pwrkey_init,
+ * будильник Alarm A взведён Linux'ом; heartbeat задаёт RTC WUT.
+ *
+ * @param wakeup_after_s Интервал heartbeat-пробуждения (RTC WUT), НЕ полный
+ * дедлайн: обязан быть меньше периода IWDG 10 с (IWDG считает и в Standby,
+ * а "кормит" его только перезапуск при сбросе-пробуждении) - см.
+ * WBEC_SUSPEND_STANDBY_HEARTBEAT_S в config.h.
+ */
+void linux_cpu_pwr_seq_suspend_to_standby(uint16_t wakeup_after_s)
+{
+    standby_pull(&gpio_pmic_pwron, false);
+    standby_pull(&gpio_pmic_reset_pwrok, false);
+
+    // Если система живёт от WBMZ (step-up включён, Vin нет), его enable
+    // (EC_GPIO_WBMZ_STEPUP_ENABLE) в Standby повиснет и step-up выключится -
+    // 5В пропадёт и DRAM умрёт. Держим enable внутренней подтяжкой вверх
+    // (~40 кОм; проверить на стенде, что её хватает входу enable на WBMZ).
+    if (wbmz_is_stepup_enabled()) {
+        static const gpio_pin_t gpio_wbmz_stepup = { EC_GPIO_WBMZ_STEPUP_ENABLE };
+        standby_pull(&gpio_wbmz_stepup, true);
+    }
+
+    // Apply pull-up and pull-down configuration
+    PWR->CR3 |= PWR_CR3_APC;
+
+    mcu_goto_standby(wakeup_after_s);
+    // На железе не возвращается: Standby, пробуждение = сброс, разбор в
+    // wbec_init(). В юнит-тестах mcu_goto_standby - заглушка и возвращается.
+}
+
+/**
+ * @brief Инициализация управления питанием при пробуждении из suspend-to-off
+ * Standby и взведение последовательности пробуждения PMIC.
+ *
+ * Пробуждение из Standby - это сброс: подтяжки PWR и режимы GPIO уже в
+ * значениях по умолчанию, чистить нечего. 5В всё это время держал внешний R38
+ * (пин был high-Z), поэтому берём пин под драйвер без провала уровня: сначала
+ * защёлка ODR=1, затем перевод в OUTPUT. Дальше та же последовательность, что
+ * и в linux_cpu_pwr_seq_wakeup: ждём появления 3.3В, затем импульс PWROK
+ * выводит SoC из сброса (а если 3.3В уже есть - поздний отказ SoC от suspend -
+ * последовательность увидит готовое 3.3В и обойдётся без "нажатия" PWRON).
+ */
+void linux_cpu_pwr_seq_resume_init(void)
+{
+    linux_cpu_pwr_5v_gpio_on();
+    GPIO_S_SET_OUTPUT(gpio_linux_power);
+
+    pmic_pwron_gpio_off();
+    pmic_reset_gpio_off();
+    GPIO_S_SET_OUTPUT(gpio_pmic_reset_pwrok);
+    GPIO_S_SET_OUTPUT(gpio_pmic_pwron);
+
+    pwr_ctx.initialized = true;
+    pwr_ctx.wake_pending = true;
+    new_state(PS_ON_STEP1_WAIT_3V3);
+}
+
 /**
  * @brief Включает питание линукс штатным способом:
  * Включается 5В, затем контролируется появление 3.3В.

--- a/src/mcu-pwr.c
+++ b/src/mcu-pwr.c
@@ -5,10 +5,24 @@
 
 static enum mcu_poweron_reason mcu_poweron_reason = MCU_POWERON_REASON_UNKNOWN;
 
+// Признак того, что текущий сброс - это выход из Standby (флаг SBF был взведён
+// на момент mcu_init_poweron_reason). Нужен, чтобы отличить пробуждение из
+// Standby от холодного старта при разборе метки suspend-to-off: метку хранит
+// VBAT, она переживает и полное обесточивание, когда DRAM уже мертва.
+static bool woke_from_standby = false;
+
+// Backup-регистры TAMP для окна suspend-to-off.
+// Индекс 0 занят состоянием линии 5В (mcu_save_vcc_5v_last_state).
+// Сигнатура - произвольная 32-битная метка ("SSB2"), маловероятная как мусор.
+#define MCU_SUSPEND_MAGIC_BKP_IDX       1
+#define MCU_SUSPEND_REMAINING_BKP_IDX   2
+#define MCU_SUSPEND_MAGIC               0x53534232u
+
 // Вызывать один раз в начале main
 void mcu_init_poweron_reason(void)
 {
     if (PWR->SR1 & PWR_SR1_SBF) {
+        woke_from_standby = true;
         PWR->SCR = PWR_SCR_CSBF;
         if (PWR->SR1 & (1 << (EC_GPIO_PWRKEY_WKUP_NUM - 1 + PWR_SR1_WUF1_Pos))) {
             PWR->SCR = (1 << (EC_GPIO_PWRKEY_WKUP_NUM - 1 + PWR_SCR_CWUF1_Pos));
@@ -59,6 +73,28 @@ void mcu_goto_standby(uint16_t wakeup_after_s)
         __DSB();
         __WFI();
     };
+}
+
+void mcu_suspend_arm(uint32_t remaining_deadline_s)
+{
+    rtc_save_to_tamper_reg(MCU_SUSPEND_REMAINING_BKP_IDX, remaining_deadline_s);
+    rtc_save_to_tamper_reg(MCU_SUSPEND_MAGIC_BKP_IDX, MCU_SUSPEND_MAGIC);
+}
+
+bool mcu_suspend_take_resume(void)
+{
+    uint32_t sig = rtc_get_tamper_reg(MCU_SUSPEND_MAGIC_BKP_IDX);
+    // Потребляем метку безусловно: она должна пережить ровно один переход
+    // Standby -> wake. Если это НЕ пробуждение из Standby (POR после
+    // обесточивания, NRST, перепрошивка), метка стирается и загрузка идёт
+    // холодным путём - DRAM в этих случаях доверять уже нельзя.
+    rtc_save_to_tamper_reg(MCU_SUSPEND_MAGIC_BKP_IDX, 0);
+    return woke_from_standby && (sig == MCU_SUSPEND_MAGIC);
+}
+
+uint32_t mcu_suspend_get_remaining_s(void)
+{
+    return rtc_get_tamper_reg(MCU_SUSPEND_REMAINING_BKP_IDX);
 }
 
 enum mcu_vcc_5v_state mcu_get_vcc_5v_last_state(void)

--- a/src/wbec.c
+++ b/src/wbec.c
@@ -213,6 +213,17 @@ static inline enum linux_powerctrl_req get_linux_powerctrl_req(void)
     return ret;
 }
 
+// Длительность следующего сна окна suspend-to-off: не дольше heartbeat
+// (инвариант IWDG: EC не спит дольше 5 с, см. WBEC_SUSPEND_STANDBY_HEARTBEAT_S)
+// и не дольше остатка дедлайна.
+static uint16_t suspend_next_sleep_s(uint32_t remaining_s)
+{
+    if (remaining_s > WBEC_SUSPEND_STANDBY_HEARTBEAT_S) {
+        return WBEC_SUSPEND_STANDBY_HEARTBEAT_S;
+    }
+    return (uint16_t)remaining_s; // mcu_goto_standby клампит минимум в 1 с
+}
+
 void wbec_init(void)
 {
     // Здесь нельзя инициализировать GPIO управления питанием
@@ -224,6 +235,78 @@ void wbec_init(void)
 
     enum mcu_poweron_reason mcu_poweron_reason = mcu_get_poweron_reason();
     wbec_ctx.poweron_reason = REASON_UNKNOWN;
+
+    // Пробуждение из окна suspend-to-off (EC спал в STM32 Standby).
+    // Пробуждение из Standby - это ПОЛНЫЙ СБРОС: SRAM-флаги wbec_ctx потеряны,
+    // поэтому факт "мы спали в suspend-to-off" приходит из backup-домена
+    // (метка взведена перед сном). DRAM жива (5В держало железо, см.
+    // linux_cpu_pwr_seq_suspend_to_standby), PMIC спит - холодная загрузка
+    // недопустима: её побочные эффекты (бип, перезапуск последовательности
+    // питания) разрушат self-refresh. Разбираем причину пробуждения:
+    if (mcu_suspend_take_resume()) {
+        uint32_t remaining_s = mcu_suspend_get_remaining_s();
+        switch (mcu_poweron_reason) {
+        case MCU_POWERON_REASON_RTC_PERIODIC_WAKEUP:
+            // Heartbeat: сам сброс уже перезапустил IWDG (окно сна < 10 с).
+            // Продвигаем остаток дедлайна и, если причин просыпаться нет,
+            // спим дальше.
+            if (remaining_s > WBEC_SUSPEND_STANDBY_HEARTBEAT_S) {
+                remaining_s -= WBEC_SUSPEND_STANDBY_HEARTBEAT_S;
+                // Поздний отказ SoC от suspend: 3.3В вернулось - SoC уже жив.
+                // Тогда не спим дальше, а возобновляемся сразу (максимум через
+                // один heartbeat после возврата 3.3В): последовательность
+                // пробуждения увидит готовое 3.3В и обойдётся без PWRON.
+                if (!vmon_check_ch_once(VMON_CHANNEL_V33)) {
+                    mcu_suspend_arm(remaining_s);
+                    linux_cpu_pwr_seq_suspend_to_standby(suspend_next_sleep_s(remaining_s));
+                    return; // на железе недостижимо (Standby); в тестах - выход
+                }
+            }
+            // Дедлайн истёк (или SoC уже жив): будим SoC сами.
+            wbec_ctx.poweron_reason = REASON_WATCHDOG;
+            break;
+
+        case MCU_POWERON_REASON_POWER_KEY:
+            // Как и в poweroff: подтверждаем нажатие антидребезгом. Случайное
+            // касание не будит систему - спим дальше; остаток дедлайна не
+            // трогаем (дрейф на время бодрствования покрыт запасом +10 с в
+            // suspend_timeout_ms).
+            while (!pwrkey_ready()) {
+                pwrkey_do_periodic_work();
+                watchdog_reload();
+            }
+            if (!pwrkey_pressed()) {
+                mcu_suspend_arm(remaining_s);
+                linux_cpu_pwr_seq_suspend_to_standby(suspend_next_sleep_s(remaining_s));
+                return; // на железе недостижимо (Standby); в тестах - выход
+            }
+            wbec_ctx.poweron_reason = REASON_POWER_KEY;
+            break;
+
+        case MCU_POWERON_REASON_RTC_ALARM:
+            // Будильник Alarm A - запрошенное Linux'ом пробуждение.
+            wbec_ctx.poweron_reason = REASON_RTC_ALARM;
+            break;
+
+        default:
+            // Сброс со взведённой меткой, но неожиданной причиной (например,
+            // IWDG-сброс прямо в Standby - heartbeat такого не допускает).
+            // Безопасное действие одно: разбудить SoC.
+            wbec_ctx.poweron_reason = REASON_WATCHDOG;
+            break;
+        }
+
+        // Resume: будим SoC той же последовательностью, что и
+        // linux_cpu_pwr_seq_wakeup (появление 3.3В -> импульс PWROK).
+        // Heartbeat-WUT больше не нужен. Бип на входе в WORKING обязан
+        // молчать: resume - это ре-инициализация DRAM поверх self-refresh
+        // (проверено: бип на resume -> cold-boot).
+        rtc_disable_periodic_wakeup();
+        wbec_ctx.suspend_resume_no_beep = true;
+        linux_cpu_pwr_seq_resume_init();
+        new_state(WBEC_STATE_POWER_ON_SEQUENCE_WAIT);
+        return;
+    }
 
     bool vcc_5v_ok = vmon_check_ch_once(VMON_CHANNEL_V50);
     enum mcu_vcc_5v_state vcc_5v_last_state = mcu_get_vcc_5v_last_state();
@@ -658,25 +741,35 @@ void wbec_do_periodic_work(void)
             break;
         }
 
-        // Suspend-to-off: питание SoC выключено самим PMIC (кроме
-        // DRAM), Linux заморожен в самообновляющейся памяти. Будим
-        // PMIC по будильнику, дедлайну или кнопке: перезапуск
-        // последовательности включения "нажимает" PWRON, PMIC
-        // восстанавливает записанную конфигурацию питания.
+        // Suspend-to-off: питание SoC выключено самим PMIC (кроме DRAM), Linux
+        // заморожен в самообновляющейся памяти. Как только сон реально начался
+        // (3.3В пропало -> suspend_started), EC уходит в STM32 Standby - тем же
+        // механизмом, что и обычный poweroff, но с двумя отличиями:
+        //  - 5В остаётся включённым (его держит внешняя схема ключа при high-Z
+        //    пине - см. linux_cpu_pwr_seq_suspend_to_standby), PMIC хранит
+        //    DRAM в self-refresh;
+        //  - RTC WUT будит EC каждые WBEC_SUSPEND_STANDBY_HEARTBEAT_S (< 10 с
+        //    IWDG): каждое пробуждение - сброс, загрузка перезапускает IWDG,
+        //    остаток дедлайна ведётся в backup-регистре.
+        // Пробуждение (будильник Linux / кнопка / дедлайн / heartbeat)
+        // разбирает wbec_init() - см. ветку mcu_suspend_take_resume().
         if (wbec_ctx.suspend_mode && wbec_ctx.suspend_off_mode &&
             wbec_ctx.suspend_started) {
+            // Защита: если будильник или кнопка сработали в коротком окне
+            // ПЕРЕД уходом в сон - просыпаемся на месте (уход в Standby
+            // разоружил бы уже считанный будильник). Дедлайн здесь не
+            // проверяем: он живёт в backup-регистре и обслуживается
+            // heartbeat-пробуждениями.
             bool alarm = rtc_alarm_take_fired();
-            bool deadline = systick_get_time_since_timestamp(
-                wbec_ctx.suspend_entry_timestamp) > wbec_ctx.suspend_timeout_ms;
             bool button = pwrkey_handle_short_press();
 
-            if (alarm || deadline || button) {
+            if (alarm || button) {
                 wbec_ctx.suspend_mode = false;
                 wbec_ctx.suspend_off_mode = false;
-                // Разоружаем «сон начался»: пробуждение по будильнику - это
-                // resume того же ядра, ЕС не перезапускается, поэтому без
-                // сброса флаг остаётся взведён и на следующем цикле первое
-                // же кормление watchdog завершит suspend немедленно.
+                // Разоружаем «сон начался»: пробуждение на месте - это resume
+                // того же ядра, ЕС не перезапускается, поэтому без сброса флаг
+                // остаётся взведён и на следующем цикле первое же кормление
+                // watchdog завершит suspend немедленно.
                 wbec_ctx.suspend_started = false;
                 // Это resume того же ядра (DRAM в самообновлении): бип на
                 // входе в WORKING сорвёт ре-инициализацию DRAM и уронит плату
@@ -685,13 +778,11 @@ void wbec_do_periodic_work(void)
                 wbec_ctx.suspend_resume_no_beep = true;
                 if (alarm) {
                     wbec_ctx.poweron_reason = REASON_RTC_ALARM;
-                } else if (button) {
-                    wbec_ctx.poweron_reason = REASON_POWER_KEY;
                 } else {
-                    wbec_ctx.poweron_reason = REASON_WATCHDOG;
+                    wbec_ctx.poweron_reason = REASON_POWER_KEY;
                 }
                 console_print("\r\n\n");
-                console_print_w_prefix("Suspend-to-off: wake up, restart PMIC via PWRON\r\n");
+                console_print_w_prefix("Suspend-to-off: wake before Standby, restart PMIC via PWRON\r\n");
                 linux_cpu_pwr_seq_wakeup();
                 new_state(WBEC_STATE_POWER_ON_SEQUENCE_WAIT);
                 break;
@@ -699,6 +790,17 @@ void wbec_do_periodic_work(void)
             // Кормления watchdog в этом режиме невозможны (Linux
             // выключен) - потребляем возможный таймаут вхолостую
             (void)wdt_handle_timed_out();
+
+            // Причин просыпаться нет: сохраняем остаток дедлайна (в нём уже
+            // есть запас +10 с, см. запись SUSPEND_CTRL) в backup-домен и
+            // уходим в Standby до heartbeat / будильника / кнопки.
+            uint32_t remaining_s = wbec_ctx.suspend_timeout_ms / 1000;
+            console_print("\r\n\n");
+            console_print_w_prefix("Suspend-to-off: EC entering STM32 Standby (heartbeat wakeups)\r\n");
+            mcu_suspend_arm(remaining_s);
+            linux_cpu_pwr_seq_suspend_to_standby(suspend_next_sleep_s(remaining_s));
+            // На железе не возвращается (Standby, пробуждение = сброс).
+            // В юнит-тестах заглушка возвращается - продолжаем цикл.
             break;
         }
 

--- a/unittests/utest_helpers/mcu-pwr/utest_mcu_pwr.c
+++ b/unittests/utest_helpers/mcu-pwr/utest_mcu_pwr.c
@@ -6,11 +6,17 @@ static struct {
     enum mcu_vcc_5v_state vcc_5v_state;
     bool init_called;
     uint16_t standby_wakeup_time;
+    bool suspend_resume_pending;
+    bool suspend_armed;
+    uint32_t suspend_remaining_s;
 } mcu_state = {
     .poweron_reason = MCU_POWERON_REASON_POWER_ON,
     .vcc_5v_state = MCU_VCC_5V_STATE_OFF,
     .init_called = false,
     .standby_wakeup_time = 0,
+    .suspend_resume_pending = false,
+    .suspend_armed = false,
+    .suspend_remaining_s = 0,
 };
 
 // Реализация функций из mcu-pwr.h
@@ -39,6 +45,26 @@ void mcu_save_vcc_5v_last_state(enum mcu_vcc_5v_state state)
     mcu_state.vcc_5v_state = state;
 }
 
+// --- suspend-to-off: метка и остаток дедлайна в "backup-домене" мока ---
+
+void mcu_suspend_arm(uint32_t remaining_deadline_s)
+{
+    mcu_state.suspend_armed = true;
+    mcu_state.suspend_remaining_s = remaining_deadline_s;
+}
+
+bool mcu_suspend_take_resume(void)
+{
+    bool ret = mcu_state.suspend_resume_pending;
+    mcu_state.suspend_resume_pending = false;
+    return ret;
+}
+
+uint32_t mcu_suspend_get_remaining_s(void)
+{
+    return mcu_state.suspend_remaining_s;
+}
+
 // Функции для тестирования
 void utest_mcu_set_poweron_reason(enum mcu_poweron_reason reason)
 {
@@ -60,10 +86,33 @@ uint16_t utest_mcu_get_standby_wakeup_time(void)
     return mcu_state.standby_wakeup_time;
 }
 
+void utest_mcu_set_suspend_resume(bool pending)
+{
+    mcu_state.suspend_resume_pending = pending;
+}
+
+void utest_mcu_set_suspend_remaining_s(uint32_t remaining_s)
+{
+    mcu_state.suspend_remaining_s = remaining_s;
+}
+
+bool utest_mcu_was_suspend_armed(void)
+{
+    return mcu_state.suspend_armed;
+}
+
+uint32_t utest_mcu_get_suspend_remaining_s(void)
+{
+    return mcu_state.suspend_remaining_s;
+}
+
 void utest_mcu_reset(void)
 {
     mcu_state.poweron_reason = MCU_POWERON_REASON_POWER_ON;
     mcu_state.vcc_5v_state = MCU_VCC_5V_STATE_OFF;
     mcu_state.init_called = false;
     mcu_state.standby_wakeup_time = 0;
+    mcu_state.suspend_resume_pending = false;
+    mcu_state.suspend_armed = false;
+    mcu_state.suspend_remaining_s = 0;
 }

--- a/unittests/utest_helpers/mcu-pwr/utest_mcu_pwr.h
+++ b/unittests/utest_helpers/mcu-pwr/utest_mcu_pwr.h
@@ -16,5 +16,16 @@ bool utest_mcu_was_init_called(void);
 // Получить параметр wakeup_after_s последнего вызова mcu_goto_standby()
 uint16_t utest_mcu_get_standby_wakeup_time(void);
 
+// --- suspend-to-off: метка и остаток дедлайна ---
+// Задать значение, которое (один раз) вернёт mcu_suspend_take_resume() -
+// эмуляция пробуждения-сброса из suspend-to-off Standby.
+void utest_mcu_set_suspend_resume(bool pending);
+// Задать остаток дедлайна, который вернёт mcu_suspend_get_remaining_s().
+void utest_mcu_set_suspend_remaining_s(uint32_t remaining_s);
+// Был ли вызван mcu_suspend_arm() (взведение метки перед Standby).
+bool utest_mcu_was_suspend_armed(void);
+// Остаток дедлайна, сохранённый последним mcu_suspend_arm().
+uint32_t utest_mcu_get_suspend_remaining_s(void);
+
 // Сбросить состояние мока
 void utest_mcu_reset(void);

--- a/unittests/wbec-integration/wbec_integration_test.c
+++ b/unittests/wbec-integration/wbec_integration_test.c
@@ -705,6 +705,34 @@ static void test_suspend_off_second_cycle_sleeps_with_watchdog(void)
         "cycle 2 must still wake on a fresh alarm");
 }
 
+// Контракт входа в окно suspend-to-off (Standby): EC уходит в Standby с
+// интервалом не длиннее heartbeat (инвариант IWDG: сон < 10 с - корень провала
+// ec0bef4) и взводит метку resume с остатком дедлайна (запрошенное время +
+// запас +10 с из suspend_timeout_ms).
+static void test_suspend_off_entry_sleeps_one_heartbeat_with_marker(void)
+{
+    sim.check_invariants = false;
+    sim.soc_feeds = true;
+    sim_boot_to_working();
+
+    sim_announce_off_mode(60);
+    sim_tick();
+    sim.pmic_crashed = true;          // BL31 снял 3.3В -> suspend_started
+    sim_run_ms(500);
+
+    TEST_ASSERT_TRUE_MESSAGE(sim.standby_requested,
+        "Suspend window entry must request Standby");
+    TEST_ASSERT_TRUE_MESSAGE(utest_mcu_get_standby_wakeup_time() > 0,
+        "Standby must be armed with a nonzero RTC WUT interval");
+    TEST_ASSERT_TRUE_MESSAGE(
+        utest_mcu_get_standby_wakeup_time() <= WBEC_SUSPEND_STANDBY_HEARTBEAT_S,
+        "Suspend Standby interval must not exceed the heartbeat (IWDG 10 s envelope)");
+    TEST_ASSERT_TRUE_MESSAGE(utest_mcu_was_suspend_armed(),
+        "Suspend window entry must arm the resume marker");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(70, utest_mcu_get_suspend_remaining_s(),
+        "Marker must carry the padded deadline remainder (60 s + 10 s slack)");
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -720,6 +748,7 @@ int main(void)
     RUN_TEST(test_suspend_off_fresh_alarm_wakes);
     RUN_TEST(test_suspend_off_exit_disarms_feed_exit);
     RUN_TEST(test_suspend_off_second_cycle_sleeps_with_watchdog);
+    RUN_TEST(test_suspend_off_entry_sleeps_one_heartbeat_with_marker);
 #if defined(WBEC_HAS_WARM_RESET)
     RUN_TEST(test_escalation_alternates_warm_and_hard);
 #endif

--- a/unittests/wbec/wbec_test.c
+++ b/unittests/wbec/wbec_test.c
@@ -327,6 +327,211 @@ static void test_init_periodic_wakeup_no_5v_was_off_no_extra_save(void)
                               "VCC 5V state must stay OFF without rewrite");
 }
 
+// ==================== wbec_init: окно suspend-to-off (Standby) ====================
+// Во время окна suspend-to-off EC спит в Standby; каждое пробуждение - сброс,
+// и wbec_init разбирает его по метке в backup-домене (mcu_suspend_take_resume).
+
+// Сценарий: пробуждение по будильнику RTC (запрошенное Linux'ом) со взведённой
+// меткой suspend-to-off.
+// Ожидание: НЕ холодная загрузка и НЕ standby, а ветка resume:
+//   - linux_cpu_pwr_seq_resume_init() вызвана (5В перехвачено, PWROK разбудит SoC),
+//   - heartbeat-WUT выключен,
+//   - переход в POWER_ON_SEQUENCE_WAIT (LED blink 50/50),
+//   - poweron_reason = RTC_ALARM.
+static void test_init_suspend_resume_from_alarm(void)
+{
+    utest_mcu_set_suspend_resume(true);
+    utest_mcu_set_suspend_remaining_s(60);
+    utest_mcu_set_poweron_reason(MCU_POWERON_REASON_RTC_ALARM);
+
+    wbec_init();
+
+    TEST_ASSERT_TRUE_MESSAGE(utest_linux_pwr_get_resume_init_called(),
+        "resume from suspend Standby must call linux_cpu_pwr_seq_resume_init");
+    TEST_ASSERT_TRUE_MESSAGE(utest_rtc_get_periodic_wakeup_disabled(),
+        "resume must disable the heartbeat WUT");
+    TEST_ASSERT_FALSE_MESSAGE(utest_linux_pwr_get_suspend_standby_called(),
+        "alarm resume must NOT go back to Standby");
+    TEST_ASSERT_FALSE_MESSAGE(utest_linux_pwr_get_standby_called(),
+        "alarm resume must NOT go to poweroff-standby");
+    TEST_ASSERT_FALSE_MESSAGE(utest_linux_pwr_get_init_called(),
+        "resume must NOT run the cold-boot power-on init");
+
+    uint16_t on_ms, off_ms;
+    utest_system_led_get_blink_params(&on_ms, &off_ms);
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(50, on_ms,
+        "resume must land in POWER_ON_SEQUENCE_WAIT (LED 50/50)");
+
+    // poweron_reason пишется в regmap на первом periodic work; остаёмся в
+    // POWER_ON_SEQUENCE_WAIT (busy), чтобы не уехать в WORKING.
+    utest_linux_pwr_set_busy(true);
+    wbec_do_periodic_work();
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(UTEST_REASON_RTC_ALARM, get_poweron_reason_from_regmap(),
+        "resume by alarm must report REASON_RTC_ALARM");
+}
+
+// Сценарий: heartbeat-пробуждение (RTC WUT) в середине окна - остаток дедлайна
+// велик, 3.3В отсутствует (SoC спит).
+// Ожидание: EC продвигает остаток на heartbeat и возвращается в Standby через
+// suspend_to_standby (5В сохраняется); resume НЕ выполняется; poweroff-standby
+// НЕ вызывается.
+static void test_init_suspend_heartbeat_reenters_standby(void)
+{
+    utest_mcu_set_suspend_resume(true);
+    utest_mcu_set_suspend_remaining_s(60);
+    utest_mcu_set_poweron_reason(MCU_POWERON_REASON_RTC_PERIODIC_WAKEUP);
+    utest_vmon_set_ch_status(VMON_CHANNEL_V33, false);
+
+    wbec_init();
+
+    TEST_ASSERT_TRUE_MESSAGE(utest_linux_pwr_get_suspend_standby_called(),
+        "heartbeat must re-enter suspend Standby");
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(WBEC_SUSPEND_STANDBY_HEARTBEAT_S,
+        utest_linux_pwr_get_suspend_standby_wakeup_s(),
+        "heartbeat sleep interval must be the heartbeat period");
+    TEST_ASSERT_TRUE_MESSAGE(utest_mcu_was_suspend_armed(),
+        "heartbeat must re-arm the suspend marker before sleeping");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(60 - WBEC_SUSPEND_STANDBY_HEARTBEAT_S,
+        utest_mcu_get_suspend_remaining_s(),
+        "heartbeat must advance the deadline remainder by one heartbeat");
+    TEST_ASSERT_FALSE_MESSAGE(utest_linux_pwr_get_resume_init_called(),
+        "heartbeat must NOT resume");
+    TEST_ASSERT_FALSE_MESSAGE(utest_linux_pwr_get_standby_called(),
+        "heartbeat must NOT go to poweroff-standby (it would cut 5V and kill DRAM)");
+    TEST_ASSERT_FALSE_MESSAGE(utest_linux_pwr_get_init_called(),
+        "heartbeat must NOT run the cold-boot power-on init");
+}
+
+// Сценарий-регрессия корня провала ec0bef4: окно сна НИКОГДА не длиннее
+// heartbeat, даже при огромном остатке дедлайна. IWDG считает и в Standby
+// (период 10 с, wdt-stm32.h), кормит его только сброс-пробуждение - значит
+// сон обязан быть короче 10 с.
+static void test_init_suspend_sleep_never_exceeds_iwdg_margin(void)
+{
+    TEST_ASSERT_LESS_THAN_MESSAGE(10, WBEC_SUSPEND_STANDBY_HEARTBEAT_S,
+        "heartbeat must be shorter than the 10 s IWDG period");
+
+    utest_mcu_set_suspend_resume(true);
+    utest_mcu_set_suspend_remaining_s(0xFFFFFFFFu);
+    utest_mcu_set_poweron_reason(MCU_POWERON_REASON_RTC_PERIODIC_WAKEUP);
+    utest_vmon_set_ch_status(VMON_CHANNEL_V33, false);
+
+    wbec_init();
+
+    TEST_ASSERT_TRUE(utest_linux_pwr_get_suspend_standby_called());
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(WBEC_SUSPEND_STANDBY_HEARTBEAT_S,
+        utest_linux_pwr_get_suspend_standby_wakeup_s(),
+        "sleep interval must never exceed the heartbeat (IWDG envelope)");
+}
+
+// Сценарий: heartbeat-пробуждение, остаток дедлайна исчерпан (система не
+// проснулась к сроку сама).
+// Ожидание: resume с причиной WATCHDOG - EC будит SoC сам.
+static void test_init_suspend_deadline_resumes_reason_watchdog(void)
+{
+    utest_mcu_set_suspend_resume(true);
+    utest_mcu_set_suspend_remaining_s(WBEC_SUSPEND_STANDBY_HEARTBEAT_S);
+    utest_mcu_set_poweron_reason(MCU_POWERON_REASON_RTC_PERIODIC_WAKEUP);
+    utest_vmon_set_ch_status(VMON_CHANNEL_V33, false);
+
+    wbec_init();
+
+    TEST_ASSERT_TRUE_MESSAGE(utest_linux_pwr_get_resume_init_called(),
+        "deadline must resume via resume_init");
+    TEST_ASSERT_FALSE_MESSAGE(utest_linux_pwr_get_suspend_standby_called(),
+        "deadline must NOT go back to sleep");
+
+    utest_linux_pwr_set_busy(true);
+    wbec_do_periodic_work();
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(UTEST_REASON_WATCHDOG, get_poweron_reason_from_regmap(),
+        "deadline resume must report REASON_WATCHDOG");
+}
+
+// Сценарий: heartbeat-пробуждение, но 3.3В присутствует - SoC сам отказался от
+// suspend уже после ухода EC в сон (поздний abort).
+// Ожидание: не спать дальше, а возобновиться немедленно (максимум через один
+// heartbeat после возврата 3.3В) - последовательность пробуждения увидит
+// готовое 3.3В.
+static void test_init_suspend_heartbeat_soc_alive_resumes(void)
+{
+    utest_mcu_set_suspend_resume(true);
+    utest_mcu_set_suspend_remaining_s(60);
+    utest_mcu_set_poweron_reason(MCU_POWERON_REASON_RTC_PERIODIC_WAKEUP);
+    utest_vmon_set_ch_status(VMON_CHANNEL_V33, true);
+
+    wbec_init();
+
+    TEST_ASSERT_TRUE_MESSAGE(utest_linux_pwr_get_resume_init_called(),
+        "SoC alive mid-window (late suspend abort) must resume immediately");
+    TEST_ASSERT_FALSE_MESSAGE(utest_linux_pwr_get_suspend_standby_called(),
+        "SoC alive mid-window must NOT re-enter Standby");
+}
+
+// Сценарий: пробуждение по кнопке, нажатие подтверждено антидребезгом.
+// Ожидание: resume с причиной POWER_KEY.
+static void test_init_suspend_button_press_resumes(void)
+{
+    utest_mcu_set_suspend_resume(true);
+    utest_mcu_set_suspend_remaining_s(60);
+    utest_mcu_set_poweron_reason(MCU_POWERON_REASON_POWER_KEY);
+    utest_set_pwrkey_pressed(true);
+
+    wbec_init();
+
+    TEST_ASSERT_TRUE_MESSAGE(utest_linux_pwr_get_resume_init_called(),
+        "confirmed button press must resume");
+
+    utest_linux_pwr_set_busy(true);
+    wbec_do_periodic_work();
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(UTEST_REASON_POWER_KEY, get_poweron_reason_from_regmap(),
+        "button resume must report REASON_POWER_KEY");
+}
+
+// Сценарий: пробуждение по кнопке, но нажатие НЕ подтвердилось (случайное
+// касание / дребезг).
+// Ожидание: EC спит дальше, остаток дедлайна не изменён (фильтр случайных
+// касаний, как в poweroff).
+static void test_init_suspend_button_brush_reenters_standby(void)
+{
+    utest_mcu_set_suspend_resume(true);
+    utest_mcu_set_suspend_remaining_s(60);
+    utest_mcu_set_poweron_reason(MCU_POWERON_REASON_POWER_KEY);
+    utest_set_pwrkey_pressed(false);
+
+    wbec_init();
+
+    TEST_ASSERT_TRUE_MESSAGE(utest_linux_pwr_get_suspend_standby_called(),
+        "unconfirmed button brush must re-enter suspend Standby");
+    TEST_ASSERT_FALSE_MESSAGE(utest_linux_pwr_get_resume_init_called(),
+        "unconfirmed button brush must NOT resume");
+    TEST_ASSERT_TRUE(utest_mcu_was_suspend_armed());
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(60, utest_mcu_get_suspend_remaining_s(),
+        "button brush must NOT advance the deadline remainder");
+}
+
+// Сценарий: сброс со взведённой меткой, но неожиданной причиной (например,
+// IWDG-сброс прямо в Standby - heartbeat такого не допускает, но защищаемся).
+// Ожидание: единственное безопасное действие - разбудить SoC (resume,
+// причина WATCHDOG), а не спать дальше и не делать холодную загрузку.
+static void test_init_suspend_unexpected_reason_resumes(void)
+{
+    utest_mcu_set_suspend_resume(true);
+    utest_mcu_set_suspend_remaining_s(60);
+    utest_mcu_set_poweron_reason(MCU_POWERON_REASON_UNKNOWN);
+
+    wbec_init();
+
+    TEST_ASSERT_TRUE_MESSAGE(utest_linux_pwr_get_resume_init_called(),
+        "unexpected reset with the suspend marker must resume (safe action)");
+    TEST_ASSERT_FALSE_MESSAGE(utest_linux_pwr_get_suspend_standby_called(),
+        "unexpected reset must NOT blindly re-enter Standby");
+
+    utest_linux_pwr_set_busy(true);
+    wbec_do_periodic_work();
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(UTEST_REASON_WATCHDOG, get_poweron_reason_from_regmap(),
+        "unexpected-reset resume must report REASON_WATCHDOG");
+}
+
 // ======================== wbec_init: общие проверки ========================
 
 // Сценарий: при отсутствии +5В после любого штатного включения должен включаться wbmz stepup.
@@ -1409,6 +1614,16 @@ int main(void)
     RUN_TEST(test_init_periodic_wakeup_no_5v_was_on_saves_state);
     RUN_TEST(test_init_periodic_wakeup_no_5v_was_off_goes_to_standby);
     RUN_TEST(test_init_periodic_wakeup_no_5v_was_off_no_extra_save);
+
+    // Окно suspend-to-off (Standby): разбор пробуждений в wbec_init
+    RUN_TEST(test_init_suspend_resume_from_alarm);
+    RUN_TEST(test_init_suspend_heartbeat_reenters_standby);
+    RUN_TEST(test_init_suspend_sleep_never_exceeds_iwdg_margin);
+    RUN_TEST(test_init_suspend_deadline_resumes_reason_watchdog);
+    RUN_TEST(test_init_suspend_heartbeat_soc_alive_resumes);
+    RUN_TEST(test_init_suspend_button_press_resumes);
+    RUN_TEST(test_init_suspend_button_brush_reenters_standby);
+    RUN_TEST(test_init_suspend_unexpected_reason_resumes);
 
     // Общие проверки init
     RUN_TEST(test_init_enables_stepup_when_no_5v);

--- a/unittests/wbec/wbec_test_stubs.c
+++ b/unittests/wbec/wbec_test_stubs.c
@@ -14,6 +14,9 @@ static struct {
     bool is_busy;
     bool standby_called;
     uint16_t standby_wakeup_s;
+    bool suspend_standby_called;
+    uint16_t suspend_standby_wakeup_s;
+    bool resume_init_called;
     jmp_buf *standby_exit_jmp;
 } linux_pwr_state = {0};
 
@@ -85,6 +88,34 @@ void linux_cpu_pwr_seq_off_and_goto_standby(uint16_t wakeup_after_s)
     if (linux_pwr_state.standby_exit_jmp) {
         longjmp(*linux_pwr_state.standby_exit_jmp, 1);
     }
+}
+
+void linux_cpu_pwr_seq_suspend_to_standby(uint16_t wakeup_after_s)
+{
+    linux_pwr_state.suspend_standby_called = true;
+    linux_pwr_state.suspend_standby_wakeup_s = wakeup_after_s;
+    // На железе не возвращается (Standby). В тесте возвращаемся: в wbec.c за
+    // вызовом стоит return/break, поэтому продолжение безопасно.
+}
+
+bool utest_linux_pwr_get_suspend_standby_called(void)
+{
+    return linux_pwr_state.suspend_standby_called;
+}
+
+uint16_t utest_linux_pwr_get_suspend_standby_wakeup_s(void)
+{
+    return linux_pwr_state.suspend_standby_wakeup_s;
+}
+
+void linux_cpu_pwr_seq_resume_init(void)
+{
+    linux_pwr_state.resume_init_called = true;
+}
+
+bool utest_linux_pwr_get_resume_init_called(void)
+{
+    return linux_pwr_state.resume_init_called;
 }
 
 void linux_cpu_pwr_seq_on(void)

--- a/unittests/wbec/wbec_test_stubs.h
+++ b/unittests/wbec/wbec_test_stubs.h
@@ -19,6 +19,10 @@ bool utest_linux_pwr_get_hard_reset_called(void);
 bool utest_linux_pwr_get_reset_pmic_called(void);
 bool utest_linux_pwr_get_warm_reset_called(void);
 void utest_linux_pwr_clear_warm_reset_called(void);
+// suspend-to-off Standby: вход в сон с сохранённым 5В и resume-инициализация
+bool utest_linux_pwr_get_suspend_standby_called(void);
+uint16_t utest_linux_pwr_get_suspend_standby_wakeup_s(void);
+bool utest_linux_pwr_get_resume_init_called(void);
 void utest_temp_set_ready(bool ready);
 void utest_rtc_alarm_reset(void);
 void utest_rtc_alarm_set_enabled(bool enabled);


### PR DESCRIPTION
**A/B candidate 2 of 2** for the suspend-window low-power mode (competes with the Stop 1 variant; bench A/B = gate G2). Stacked on #92.

Reuses the **proven poweroff machinery**: STM32 Standby with a **5 s heartbeat** — every wake is a reset that re-feeds the IWDG (the ec0bef4 10 s IWDG death is structurally impossible), deadline remainder persisted in TAMP BKP2R, cause-decoded resume in wbec_init shared with poweroff classification. No 5 V pull hack needed: the WB8.5.3 schematic (U14 EN: R38 470k pull-up to +5V/1) holds the module 5 V through reset/high-Z by hardware.

Wins vs Stop: ~3× smaller production diff (+281/−16, 6 files), no new execution regime (no ISRs/EXTI/clock-restore pipeline), late-SoC-abort recovery in ≤5 s (vs full-window). Tests: 427 PASS both models incl. the ec0bef4 root-cause regression (sleep interval never exceeds the heartbeat).

**Known gap (on-battery suspend)**: `wbmz_init()` drives the WBMZ step-up EN (PB15) low on every heartbeat reboot — on battery this kills the 5 V rail and DRAM. Options under discussion: (a) marker-aware glitch-free takeover in wbmz_init, (b) refuse Standby-window when on WBMZ (busy-poll fallback, ~6 lines), (c) respin: module-side RC on EN mirroring the U14 pattern. Until resolved this variant is safe on external Vin only.

The structural trade vs Stop: every heartbeat re-runs the boot path over live DRAM — "boot path must stay DRAM-safe" becomes a permanent invariant (this PB15 gap is exactly that tax, found by inspection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
